### PR TITLE
Add possibility to specify a DOWNSTREAM_WORKSPACE with ici

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -18,6 +18,7 @@ on:
       downstream_workspace:
         description: 'DOWNSTREAM_WORKSPACE variable for industrial_ci. If set, downstream packages will be built and tested against this repo'
         required: false
+        default: ''
         type: string
       ros_distro:
         description: 'ROS_DISTRO variable for industrial_ci'

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -15,6 +15,10 @@ on:
         description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
         required: true
         type: string
+      downstream_workspace:
+        description: 'DOWNSTREAM_WORKSPACE variable for industrial_ci. If set, downstream packages will be built and tested against this repo'
+        required: false
+        type: string
       ros_distro:
         description: 'ROS_DISTRO variable for industrial_ci'
         required: true
@@ -83,6 +87,7 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
+          DOWNSTREAM_WORKSPACE: ${{ inputs.downstream_workspace }}
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}


### PR DESCRIPTION
This would help raising awareness of breaking things downstream before actually releasing.

In the past we broke things downstream e.g. for ur_robot_driver or most recently webots. 

With this change we could add a set of downstream packages that we would like to check when introducing changes.

This could either be incorporated into all builds (in each PR) or into a separate workflow that e.g. runs on pushes to the main (or respective distro) branch. This would show unintentional API breaks and / or integration test failures before actually releasing things to the buildfarm.