### PR TITLE
Add target_workspace to ICI workflow

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -13,7 +13,7 @@ on:
 
       upstream_workspace:
         description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
-        required: true
+        required: false
         type: string
       target_workspace:
         description: 'TARGET_WORKSPACE variable for industrial_ci. If not provided, defaults to the current repo.'

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -15,6 +15,11 @@ on:
         description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
         required: true
         type: string
+      target_workspace:
+        description: 'TARGET_WORKSPACE variable for industrial_ci. If not provided, defaults to the current repo.'
+        required: false
+        default: ""
+        type: string
       ros_distro:
         description: 'ROS_DISTRO variable for industrial_ci'
         required: true
@@ -83,6 +88,7 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
+          TARGET_WORKSPACE: ${{ inputs.target_workspace }}
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}


### PR DESCRIPTION
This should allow to optionally change the TARGET_WORKSPACE variable for ICI.

As discussed in #2 

According to [this](https://github.com/ros-industrial/industrial_ci/blob/c2b7b619ba802b3c3ae95d400076f6e17a2d86c3/industrial_ci/src/run.sh#L45) it should work that way since

```
$ export TARGET_WORKSPACE=""
$ export TARGET_REPO_PATH="hello"
$ export TARGET_WORKSPACE=${TARGET_WORKSPACE:-$TARGET_REPO_PATH}
$ echo $TARGET_WORKSPACE
hello
$ export TARGET_WORKSPACE="world"
$ export TARGET_WORKSPACE=${TARGET_WORKSPACE:-$TARGET_REPO_PATH}
$ echo $TARGET_WORKSPACE
world
```