### PR TITLE
Add reusable workflow for coverage build

### DIFF
--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       os_name:
-        description: 'On which OS to run the linter'
+        description: 'On which OS to run the workflow, e.g. ubuntu-22.04'
         required: false
         default: 'ubuntu-latest'
         type: string

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -1,0 +1,57 @@
+name: Reusable Coverage Build
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS2 distribution name'
+        required: true
+        type: string
+      os_name:
+        description: 'On which OS to run the linter'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+
+env:
+  # this will be src/{repo-owner}/{repo-name}
+  path: src/${{ github.repository }}
+
+jobs:
+  coverage:
+    name: coverage build ${{ inputs.ros_distro }}
+    runs-on: ${{ inputs.os_name }}
+    steps:
+      - uses: ros-tooling/setup-ros@0.7.1
+        with:
+          required-ros-distributions: ${{ inputs.ros_distro }}
+      - uses: actions/checkout@v4
+      - id: package_list_action
+        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@ci_lint
+        with:
+          path: ${{ env.path }}
+      - uses: ros-tooling/action-ros-ci@0.3.6
+        with:
+          target-ros2-distro: ${{ inputs.ros_distro }}
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          # build all packages listed here
+          package-name: ${{ steps.package_list_action.outputs.package_list }}
+
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos?token=${{ secrets.GITHUB_TOKEN }}
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v4.0.1
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: colcon-logs-coverage-${{ inputs.ros_distro }}
+          path: ros_ws/log

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -31,10 +31,6 @@ jobs:
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@ci_lint
         with:
           path: ${{ env.path }}
-      - name: Debug output
-        run: |
-          echo "repo_name: ${{ steps.package_list_action.outputs.repo_name }}"
-          echo "package_list: ${{ steps.package_list_action.outputs.package_list }}"
       - uses: ros-tooling/action-ros-ci@0.3.6
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
       - uses: actions/checkout@v4
+        with:
+          path: ${{ env.path }}
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@ci_lint
         with:

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Repository upload token - get it from codecov.io'
+        required: true
 
 env:
   # this will be src/{repo-owner}/{repo-name}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -52,9 +52,6 @@ jobs:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests
           name: codecov-umbrella
-          # Repository upload token - get it from codecov.io and add it to the repository secrets
-          # from a public fork it is not necessary
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4.3.1
         with:
           name: colcon-logs-coverage-${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: ${{ env.path }}
       - id: package_list_action
-        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@ci_lint
+        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
         with:
           path: ${{ env.path }}
       - uses: ros-tooling/action-ros-ci@0.3.6

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -31,6 +31,10 @@ jobs:
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@ci_lint
         with:
           path: ${{ env.path }}
+      - name: Debug output
+        run: |
+          echo "repo_name: ${{ steps.package_list_action.outputs.repo_name }}"
+          echo "package_list: ${{ steps.package_list_action.outputs.package_list }}"
       - uses: ros-tooling/action-ros-ci@0.3.6
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -11,10 +11,6 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
-    secrets:
-      CODECOV_TOKEN:
-        description: 'Repository upload token - get it from codecov.io'
-        required: true
 
 env:
   # this will be src/{repo-owner}/{repo-name}
@@ -56,6 +52,8 @@ jobs:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests
           name: codecov-umbrella
+          # Repository upload token - get it from codecov.io and add it to the repository secrets
+          # from a public fork it is not necessary
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4.3.1
         with:


### PR DESCRIPTION
Uses the composite action introduced with #11

I'm not sure if we need the `CODECOV_TOKEN`:
https://github.com/codecov/codecov-action/blob/e0b68c6749509c5f83f984dd99a76a1c1a231044/action.yml#L5-L7
In some repositories we use it, in some we don't. 
I tried adding it as [described here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets) but got errors from the caller workflow from my fork (where I don't have/need this token).

This was tested successfully with https://github.com/ros-controls/control_toolbox/pull/188