### PR TITLE
coverage: Fail CI if codecov-action fails

### DIFF
--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -49,6 +49,7 @@ jobs:
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: codecov/codecov-action@v4.0.1
         with:
+          fail_ci_if_error: true
           file: ros_ws/lcov/total_coverage.info
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
By default, the pipeline returns success even if the upload fails. This is misleading in my opinion.