### PR TITLE
Add token instructions to codecov-action

### DIFF
--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -61,6 +61,7 @@ jobs:
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: ${{ env.path }}
+          verbose: true
 
       - uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -11,9 +11,6 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
-    secrets:
-      CODECOV_TOKEN:
-        required: true
 
 jobs:
   coverage:

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -53,6 +53,7 @@ jobs:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4.3.1
         with:
           name: colcon-logs-coverage-${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -50,6 +50,9 @@ jobs:
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - name: Workaround for codecov/feedback#263
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: codecov/codecov-action@v4.0.1
         with:
           fail_ci_if_error: true

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -57,6 +57,8 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
+          root_dir: ${{ env.path }}
+
       - uses: actions/upload-artifact@v4.3.1
         with:
           name: colcon-logs-coverage-${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Workaround for codecov/feedback#263
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - uses: codecov/codecov-action@v4.0.1
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           file: ros_ws/lcov/total_coverage.info

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -57,7 +57,7 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
-          root_dir: ${{ env.path }}
+          working-directory: ${{ env.path }}
 
       - uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -46,8 +46,6 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-
       - uses: actions/upload-artifact@v4.3.1
         with:
           name: colcon-logs-coverage-${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 env:
   # this will be src/{repo-owner}/{repo-name}


### PR DESCRIPTION
Since 4v this is required. For this to work, adding a `CODECOV_TOKEN` action secret needs to be added to the GH repository.

This should fix our problems on uploading the code coverage as discussed in https://github.com/ros-controls/control_toolbox/pull/188. Closes #15 

In the target repo a secret has to be added in the project settings:
**
![image](https://github.com/ros-controls/ros2_control_ci/assets/491645/13112298-1053-43d5-96b0-79967c0f89f4)
**

The token can be extracted on codecov.io.