### PR TITLE
Roll codecov-action back to v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "codecov/codecov-action"

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -47,7 +47,7 @@ jobs:
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: codecov/codecov-action@v4.0.1
+      - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           file: ros_ws/lcov/total_coverage.info


### PR DESCRIPTION
Until we fixed v4, see #16