### PR TITLE
[RHEL] Run dnf check-update

### DIFF
--- a/.github/workflows/reusable-rhel-binary-build.yml
+++ b/.github/workflows/reusable-rhel-binary-build.yml
@@ -61,7 +61,8 @@ jobs:
           if [[ -n "${{ inputs.upstream_workspace }}" ]]; then
             vcs import src < ${{ env.path }}/${{ inputs.upstream_workspace }}
           fi
-          rosdep update
+          dnf check-update
+          rosdep update --rosdistro ${{ inputs.ros_distro }}
           rosdep install -iyr --from-path src || true
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master


### PR DESCRIPTION
Jobs failed today because the metadata was old and there was a new sync for humble+iron.
https://github.com/ros-controls/control_toolbox/pull/190#issuecomment-1962109021

Calling `dnf check-update` should fix this.