### PR TITLE
Don't fail on dnf check-update

### DIFF
--- a/.github/workflows/reusable-rhel-binary-build.yml
+++ b/.github/workflows/reusable-rhel-binary-build.yml
@@ -61,9 +61,9 @@ jobs:
           if [[ -n "${{ inputs.upstream_workspace }}" ]]; then
             vcs import src < ${{ env.path }}/${{ inputs.upstream_workspace }}
           fi
-          dnf check-update
+          dnf check-update || true # update the cache but don't fail if there are updates available
           rosdep update --rosdistro ${{ inputs.ros_distro }}
-          rosdep install -iyr --from-path src || true
+          rosdep install -iyr --from-path src || true # ignore errors, as some packages might not be available
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
         with:


### PR DESCRIPTION
@fmauch neither am I experienced with RHEL ;)

`dnf check-update` has a nonzero exit code if there are updates -> causing the workflow to fail. 
There would be a `--refresh` option for `dnf install`, but I don't know how to pass that via rosdep.

https://github.com/ros-controls/ros2_controllers/actions/runs/8028858148/job/21943668352?pr=831#step:5:47