### PR TITLE
Fix paths for lcov/codecov

### DIFF
--- a/.github/actions/set-package-list/action.yml
+++ b/.github/actions/set-package-list/action.yml
@@ -19,6 +19,7 @@ runs:
   steps:
     - id: colcon
       run: |
+        ls ${{ inputs.path }}
         echo "package_list=$(colcon list --paths ${{ inputs.path }} --names-only | tr '\n' ' ') $(colcon list --paths ${{ inputs.path }}/* --names-only | tr '\n' ' ')" >> $GITHUB_OUTPUT
       shell: bash
     - id: split_repo

--- a/.github/actions/set-package-list/action.yml
+++ b/.github/actions/set-package-list/action.yml
@@ -4,7 +4,6 @@ description: 'Get a list of packages in the given path'
 inputs:
   path:
     description: 'Path to the repository after checkout'
-    required: true
 outputs:
   package_list:
     description: "A white-space separated list of packages"
@@ -19,7 +18,7 @@ runs:
   steps:
     - id: colcon
       run: |
-        ls ${{ inputs.path }}
+        ls -lash
         echo "package_list=$(colcon list --paths ${{ inputs.path }} --names-only | tr '\n' ' ') $(colcon list --paths ${{ inputs.path }}/* --names-only | tr '\n' ' ')" >> $GITHUB_OUTPUT
       shell: bash
     - id: split_repo

--- a/.github/actions/set-package-list/action.yml
+++ b/.github/actions/set-package-list/action.yml
@@ -18,7 +18,6 @@ runs:
   steps:
     - id: colcon
       run: |
-        ls -lash
         echo "package_list=$(colcon list --paths ${{ inputs.path }} --names-only | tr '\n' ' ') $(colcon list --paths ${{ inputs.path }}/* --names-only | tr '\n' ' ')" >> $GITHUB_OUTPUT
       shell: bash
     - id: split_repo

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -26,7 +26,7 @@ jobs:
           required-ros-distributions: ${{ inputs.ros_distro }}
       - uses: actions/checkout@v4
       - id: package_list_action
-        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@lcov_paths
+        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
       - uses: ros-tooling/action-ros-ci@0.3.6
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -27,8 +27,6 @@ jobs:
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@lcov_paths
-        with:
-          path: src
       - uses: ros-tooling/action-ros-ci@0.3.6
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -12,10 +12,6 @@ on:
         default: 'ubuntu-latest'
         type: string
 
-env:
-  # this will be src/{repo-owner}/{repo-name}
-  path: src/${{ github.repository }}
-
 jobs:
   coverage:
     name: coverage build ${{ inputs.ros_distro }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -26,7 +26,7 @@ jobs:
           required-ros-distributions: ${{ inputs.ros_distro }}
       - uses: actions/checkout@v4
       - id: package_list_action
-        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
+        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@lcov_paths
         with:
           path: src
       - uses: ros-tooling/action-ros-ci@0.3.6

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -25,12 +25,10 @@ jobs:
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
       - uses: actions/checkout@v4
-        with:
-          path: ${{ env.path }}
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
         with:
-          path: ${{ env.path }}
+          path: src
       - uses: ros-tooling/action-ros-ci@0.3.6
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}


### PR DESCRIPTION
codecov did not work with the path I configured for the checkout. It seems that the custom action still works without giving the explict path to `colcon list` -> no need for the path -> lcov/codecov works with the default path without further changes.

https://github.com/ros-controls/control_toolbox/actions/runs/8070248887/job/22050684141
https://app.codecov.io/gh/ros-controls/control_toolbox/commit/f5277a3e01eaea3557651e5d66a178df56f002b7/tree

![image](https://github.com/ros-controls/ros2_control_ci/assets/3367244/5e27235b-522d-4f5e-b66b-f9587b7c35cc)

