### PR TITLE
Automatically create an Issue on failed scheduled builds

### DIFF
--- a/.github/issue_template_failed_ci.md
+++ b/.github/issue_template_failed_ci.md
@@ -1,0 +1,5 @@
+---
+title: CI build job {{ env.ACTION_NAME }} failed!
+labels: CI
+---
+An automated scheduled build failed on `{{ env.REF }}`: {{ env.URL }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -99,6 +99,21 @@ jobs:
           ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}
           BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
+        id: ici
+      - name: Download issue template # Has to be a local file
+        if: ${{ always() && steps.ici.outcome == 'failure'}}
+        run:
+          wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/issue_on_failure/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ always() && steps.ici.outcome == 'failure'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
+          REF: ${{ inputs.ref_for_scheduled_build }}
+          URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename:  .github/issue_template_failed_ci.md
       - name: prepare target_ws for cache
         if: ${{ always() && ! matrix.env.CCOV }}
         run: |

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -101,11 +101,11 @@ jobs:
           BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
         id: ici
       - name: Download issue template # Has to be a local file
-        if: ${{ always() && steps.ici.outcome == 'failure'}}
+        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/issue_on_failure/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && steps.ici.outcome == 'failure'}}
+        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Download issue template # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
-          wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/issue_on_failure/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
+          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         env:


### PR DESCRIPTION
This should add an issue like [this](https://github.com/fmauch/control_toolbox/issues/15) when the ICI fails in a scheduled build.

See workflow run [here](https://github.com/fmauch/control_toolbox/actions/runs/8086943802/job/22100169616), where I artificially introduced a build error.

The issues data could be modified (title, labels, description...) but I would need input for that.