### PR TITLE
Create CI issue only when failing to build / test

### DIFF
--- a/.github/issue_template_failed_ci_downstream.md
+++ b/.github/issue_template_failed_ci_downstream.md
@@ -1,0 +1,7 @@
+---
+title: CI build job {{ env.ACTION_NAME }} failed on downstream workspace
+labels: CI
+---
+An automated scheduled build failed on `{{ env.REF }}`: {{ env.URL }} while building or testing the
+downstream workspace. This could be the result of a change in this repo breaking things downstream
+or an error caused because of downstream changes.

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -105,7 +105,7 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results == '1' ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results != '0' ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -115,7 +115,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace != '0' || steps.ici.outputs.downstream_test_results == '1' ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace != '0' || steps.ici.outputs.downstream_test_results != '0' ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -101,17 +101,17 @@ jobs:
           BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
         id: ici
       - name: Download issue template  for target failure  # Has to be a local file
-        if: ${{ always() && steps.ici.outcome == 'failure'}}
+        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - name: Download issue template for downstream failure  # Has to be a local file
-        if: ${{ always() && steps.ici.outcome == 'failure'}}
+        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
         # `make` and so `colcon build` returns 2 on errors, while `colcon test-result` returns 1 on
         # when any test failed.
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1')}}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -121,7 +121,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == '2' || steps.ici.outputs.downstream_test_results == '1')}}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == '2' || steps.ici.outputs.downstream_test_results == '1') && github.event_name == 'schedule'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -109,6 +109,8 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/parse_ici_output/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
+        # `make` and so `colcon build` returns 2 on errors, while `colcon test-result` returns 1 on
+        # when any test failed.
         if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1')}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Download issue template for downstream failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure'}}
         run:
-          wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/parse_ici_output/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
+          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
         # `make` and so `colcon build` returns 2 on errors, while `colcon test-result` returns 1 on
         # when any test failed.

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -101,15 +101,15 @@ jobs:
           BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
         id: ici
       - name: Download issue template  for target failure  # Has to be a local file
-        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
+        if: ${{ always() && steps.ici.outcome == 'failure'}}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - name: Download issue template for downstream failure  # Has to be a local file
-        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
+        if: ${{ always() && steps.ici.outcome == 'failure'}}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results != '0' ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results != '0' )}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -119,7 +119,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace != '0' || steps.ici.outputs.downstream_test_results != '0' ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace != '0' || steps.ici.outputs.downstream_test_results != '0' )}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -100,10 +100,14 @@ jobs:
           OS_CODE_NAME: ${{ inputs.os_code_name }}
           BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
         id: ici
-      - name: Download issue template # Has to be a local file
+      - name: Download issue template  for target failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
+      - name: Download issue template for downstream failure  # Has to be a local file
+        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
+        run:
+          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results != '0' ) && github.event_name == 'schedule' }}
         env:

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -105,7 +105,7 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace == "1" || steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results == "1" ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '1' || steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results == '1' ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -115,7 +115,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == "1" || steps.ici.outputs.run_downstream_test || steps.ici.outputs.downstream_test_results == "1" ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == '1' || steps.ici.outputs.run_downstream_test || steps.ici.outputs.downstream_test_results == '1' ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -105,7 +105,7 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == "1" || steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results == "1" ) == 'failure' && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -113,7 +113,17 @@ jobs:
           URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           update_existing: true
-          filename:  .github/issue_template_failed_ci.md
+          filename: .github/issue_template_failed_ci.md
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == "1" || steps.ici.outputs.run_downstream_test || steps.ici.outputs.downstream_test_results == "1" ) == 'failure' && github.event_name == 'schedule' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
+          REF: ${{ inputs.ref_for_scheduled_build }}
+          URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/issue_template_failed_ci_downstream.md
       - name: prepare target_ws for cache
         if: ${{ always() && ! matrix.env.CCOV }}
         run: |

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Download issue template for downstream failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure'}}
         run:
-          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
+          wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/parse_ici_output/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results != '0' )}}
         env:

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -105,7 +105,7 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '1' || steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results == '1' ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results == '1' ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -115,7 +115,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == '1' || steps.ici.outputs.run_downstream_test || steps.ici.outputs.downstream_test_results == '1' ) && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace != '0' || steps.ici.outputs.downstream_test_results == '1' ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -105,7 +105,7 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace == "1" || steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results == "1" ) == 'failure' && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == "1" || steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results == "1" ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -115,7 +115,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == "1" || steps.ici.outputs.run_downstream_test || steps.ici.outputs.downstream_test_results == "1" ) == 'failure' && github.event_name == 'schedule' }}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == "1" || steps.ici.outputs.run_downstream_test || steps.ici.outputs.downstream_test_results == "1" ) && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -109,10 +109,7 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/parse_ici_output/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
-        if: |
-          ${{ always() &&
-          ((steps.ici.outputs.build_target_workspace != '0' && steps.ici.outputs.build_target_workspace != '') ||
-           (steps.ici.outputs.target_test_results != '0' && steps.ici.outputs.target_test_results != '') )}}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1')}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -122,10 +119,7 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: |
-          ${{ always() &&
-          ((steps.ici.outputs.build_downstream_workspace != '0' && steps.ici.outputs.build_downstream_workspace != '') ||
-           (steps.ici.outputs.downstream_test_results != '0' && steps.ici.outputs.downstream_test_results != ''))}}
+        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == '2' || steps.ici.outputs.downstream_test_results == '1')}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -109,7 +109,10 @@ jobs:
         run:
           wget https://raw.githubusercontent.com/fmauch/ros2_control_ci/parse_ici_output/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace != '0' || steps.ici.outputs.target_test_results != '0' )}}
+        if: |
+          ${{ always() &&
+          ((steps.ici.outputs.build_target_workspace != '0' && steps.ici.outputs.build_target_workspace != '') ||
+           (steps.ici.outputs.target_test_results != '0' && steps.ici.outputs.target_test_results != '') )}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -119,7 +122,10 @@ jobs:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace != '0' || steps.ici.outputs.downstream_test_results != '0' )}}
+        if: |
+          ${{ always() &&
+          ((steps.ici.outputs.build_downstream_workspace != '0' && steps.ici.outputs.build_downstream_workspace != '') ||
+           (steps.ici.outputs.downstream_test_results != '0' && steps.ici.outputs.downstream_test_results != ''))}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}


### PR DESCRIPTION
Also, I've added different templates for failing the target ws vs. the downstream ws.

This should implement #28.

I haven't tested this, yet, hence the draft status. Will need another timeslot for testing this.