### PR TITLE
Pre-commit update: Add ref for scheduled build and hint for maintainers

### DIFF
--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -4,6 +4,12 @@ name: Update pre-commit
 
 on:
   workflow_call:
+    inputs:
+      ref_for_scheduled_build:
+        description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
+        type: string
 
 jobs:
   auto_update_and_create_pr:
@@ -12,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref_for_scheduled_build }}
 
       - name: Install pre-commit
         run: |
@@ -42,8 +50,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: auto-update
-          commit-message: Auto-update with pre-commit
+          branch: auto-update-${{ github.event.inputs.ref_for_scheduled_build }}
+          commit-message: Bump version of pre-commit hooks
           title: Bump version of pre-commit hooks
-          body: This pull request contains auto-updated files of pre-commit config.
+          body: This pull request contains auto-updated files of the pre-commit config.
           delete-branch: true

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -53,5 +53,6 @@ jobs:
           branch: auto-update-${{ github.event.inputs.ref_for_scheduled_build }}
           commit-message: Bump version of pre-commit hooks
           title: Bump version of pre-commit hooks
-          body: This pull request contains auto-updated files of the pre-commit config.
+          body: This pull request contains auto-updated files of the pre-commit config. @ros-controls/ros2-maintainers please run the pre-commit workflow manually on the branch `auto-update-${{ github.event.inputs.ref_for_scheduled_build }}` before merging.
           delete-branch: true
+          draft: true

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -55,4 +55,3 @@ jobs:
           title: Bump version of pre-commit hooks
           body: This pull request contains auto-updated files of the pre-commit config.
           delete-branch: true
-          draft: true

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -55,3 +55,4 @@ jobs:
           title: Bump version of pre-commit hooks
           body: This pull request contains auto-updated files of the pre-commit config.
           delete-branch: true
+          draft: true


### PR DESCRIPTION
[CI pipeline is not triggered for github-actions bot with GITHUB_TOKEN ](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.

It can happen now that pre-commit fails after an update, e.g., see [here](https://github.com/ros-controls/ros2_control_demos/actions/runs/8230532691).
I don't know how to fix this, we probably would need to create separate tokens for this workflow?

Maintainers can manually run the work due to the workflow-dispatch trigger on the newly created PR, but this won't be listed in the PR. I propose making the PR draft and add a hint for the maintainers to do so.

Furthermore, I added a `ref_for_scheduled_build` input to make the workflow configurable for other branches than master too.