### PR TITLE
Don't run reviewer lottery for `github-actions[bot]`

### DIFF
--- a/.github/workflows/reusable-reviewer-lottery.yml
+++ b/.github/workflows/reusable-reviewer-lottery.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   assign_reviewers:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]' && github.actor != 'github-actions[bot]'
     steps:
     - uses: actions/checkout@v4
     - run:


### PR DESCRIPTION
PR's generated from the workflows have `github-actions[bot]`, like the pre-commit update job.