### PR TITLE
Remove gazebo_ros2_control from rolling build

### DIFF
--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -7,10 +7,6 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
     version: ros2-master
-  ros-controls/gazebo_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gazebo_ros2_control.git
-    version: master
   ros-controls/gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Gazebo classic will never be released for Ubuntu noble.