### PR TITLE
Remove continue-on-error for debian/rhel

### DIFF
--- a/.github/workflows/reusable-debian-build.yml
+++ b/.github/workflows/reusable-debian-build.yml
@@ -68,7 +68,7 @@ jobs:
           colcon build --packages-up-to ${{ steps.package_list_action.outputs.package_list }} --packages-skip ${{ inputs.skip_packages }}
       - name: Test workspace
         shell: bash
-        continue-on-error: true
+        continue-on-error: false
         run: |
           source /opt/ros2_ws/install/setup.bash
           colcon test --packages-select ${{ steps.package_list_action.outputs.package_list }} --packages-skip ${{ inputs.skip_packages }} ${{ inputs.skip_packages_test }}

--- a/.github/workflows/reusable-rhel-binary-build.yml
+++ b/.github/workflows/reusable-rhel-binary-build.yml
@@ -77,7 +77,7 @@ jobs:
           colcon build --packages-up-to ${{ steps.package_list_action.outputs.package_list }} --packages-skip ${{ inputs.skip_packages }}
       - name: Test workspace
         shell: bash
-        continue-on-error: true
+        continue-on-error: false
         run: |
           source /opt/ros/${{ inputs.ros_distro }}/setup.bash
           source /opt/ros2_ws/install/local_setup.bash


### PR DESCRIPTION
As discussed in the WG meeting on April 10th: set the test step `continue-on-error: false` for debian and RHEL workflows, because most of the ubuntu jobs are failing atm.