### PR TITLE
Fix coverage build on rolling (temporarily)

### DIFF
--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -25,8 +25,11 @@ jobs:
           if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
             sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
             export ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml
-            rosdep update
           fi
+      - name: Test some rosdep commands
+        run: |
+          rosdep update
+          rosdep resolve test_msgs std_msgs
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ${{ inputs.os_name }}
     steps:
       - uses: ros-tooling/setup-ros@0.7.1
-        with:
-          required-ros-distributions: ${{ inputs.ros_distro }}
       - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
         run: |
           if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
@@ -29,7 +27,9 @@ jobs:
       - name: Test some rosdep commands
         run: |
           rosdep update
-          rosdep resolve test_msgs std_msgs
+          echo "ROS_DISTRO: $ROS_DISTRO"
+          rosdep resolve test_msgs std_msgs || true
+          rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
@@ -39,7 +39,6 @@ jobs:
           import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed here
           package-name: ${{ steps.package_list_action.outputs.package_list }}
-
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos?token=${{ secrets.GITHUB_TOKEN }}
           colcon-defaults: |

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
             sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
-            export ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml
+            echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
           fi
       - name: Test some rosdep commands
         run: |

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -20,6 +20,13 @@ jobs:
       - uses: ros-tooling/setup-ros@0.7.1
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
+      - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
+        run: |
+          if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
+            sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
+            export ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml
+            rosdep update
+          fi
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -19,12 +19,15 @@ jobs:
     steps:
       - uses: ros-tooling/setup-ros@0.7.1
       - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
+        # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
+        # TODO(anyone): remove/deactivate after rolling is fixed on noble
         run: |
           if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
             sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
             echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
           fi
-      - name: Test some rosdep commands
+      - name: Test some rosdep commands to see if the step above worked
+        # TODO(anyone): remove/deactivate after rolling is fixed on noble
         run: |
           rosdep update
           echo "ROS_DISTRO: $ROS_DISTRO"

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -18,19 +18,18 @@ jobs:
     runs-on: ${{ inputs.os_name }}
     steps:
       - uses: ros-tooling/setup-ros@0.7.1
-      # - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
-      #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
-      #   run: |
-      #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
-      #       sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
-      #       echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
-      #     fi
-      # - name: Test some rosdep commands
-      #   run: |
-      #     rosdep update
-      #     echo "ROS_DISTRO: $ROS_DISTRO"
-      #     rosdep resolve test_msgs std_msgs || true
-      #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
+      - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
+        run: |
+          if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
+            sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
+            echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
+          fi
+      - name: Test some rosdep commands
+        run: |
+          rosdep update
+          echo "ROS_DISTRO: $ROS_DISTRO"
+          rosdep resolve test_msgs std_msgs || true
+          rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -18,18 +18,19 @@ jobs:
     runs-on: ${{ inputs.os_name }}
     steps:
       - uses: ros-tooling/setup-ros@0.7.1
-      - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
-        run: |
-          if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
-            sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
-            echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
-          fi
-      - name: Test some rosdep commands
-        run: |
-          rosdep update
-          echo "ROS_DISTRO: $ROS_DISTRO"
-          rosdep resolve test_msgs std_msgs || true
-          rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
+      # - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
+      #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
+      #   run: |
+      #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
+      #       sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
+      #       echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
+      #     fi
+      # - name: Test some rosdep commands
+      #   run: |
+      #     rosdep update
+      #     echo "ROS_DISTRO: $ROS_DISTRO"
+      #     rosdep resolve test_msgs std_msgs || true
+      #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master


### PR DESCRIPTION
Adding a temporary fix for rosdep+jammy+rolling until noble is fully released, see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html

Removing `required-ros-distributions` for setup-ros was necessary, otherwise rosdep still didn't work.