### PR TITLE
Freeze the version of sphinx

### DIFF
--- a/.github/workflows/reusable-rosdoc2.yml
+++ b/.github/workflows/reusable-rosdoc2.yml
@@ -18,6 +18,8 @@ jobs:
           sudo apt install -y python3-pip git doxygen graphviz
           python3 -m venv .venv
           source .venv/bin/activate
+          # TODO(anyone) remove if https://github.com/sphinx-doc/sphinx/pull/12298/files is merged
+          pip install Sphinx==7.2.6
           git clone https://github.com/ros-infrastructure/rosdoc2.git
           pip install --upgrade rosdoc2/
       - uses: actions/checkout@v4


### PR DESCRIPTION
Since yesterday a new release of sphinx is out -> it is not compatible with breathe, following in failing rosdoc2 builds 
https://github.com/breathe-doc/breathe/issues/981
https://github.com/sphinx-doc/sphinx/pull/12298/files
https://github.com/ros-controls/realtime_tools/actions/runs/8716929711/job/23911232320?pr=161