### PR TITLE
Updates for noble

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -9,3 +9,4 @@ jobs:
     uses: ./.github/workflows/reusable-pre-commit.yml
     with:
       ros_distro: rolling
+      container: ubuntu:24.04

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -26,8 +26,8 @@ jobs:
       - name: "Determine prerequisites"
         id: prereq
         run: |
-          DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
-          apt install -y sudo apt-utils
+          command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
+          DEBIAN_FRONTEND=noninteractive sudo apt update && sudo apt upgrade -y
           echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
 
       # needed for github actions, and only if a bare ubuntu image is used
@@ -38,7 +38,7 @@ jobs:
         # https://github.com/nektos/act/issues/973
         if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
         run: |
-          apt install -y curl
+          sudo apt install -y curl
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -33,8 +33,6 @@ jobs:
       # needed for github actions, and only if a bare ubuntu image is used
       - uses: actions/setup-node@v4
         if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
-        # with:
-        #   node-version: 16
       - name: Install node
         # Consider switching to https://github.com/actions/setup-node when it works
         # https://github.com/nektos/act/issues/973

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -18,22 +18,20 @@ jobs:
     runs-on: ${{ inputs.os_name }}
     steps:
       - uses: ros-tooling/setup-ros@0.7.2
-      - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
-        # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
-        # TODO(anyone): remove/deactivate after rolling is fixed on noble
-        run: |
-          if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
-            sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
-            echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
-          fi
-      - name: Test some rosdep commands to see if the step above worked
-        # TODO(anyone): remove/deactivate after rolling is fixed on noble
-        run: |
-          rosdep update
-          echo "ROS_DISTRO: $ROS_DISTRO"
-          rosdep resolve test_msgs std_msgs || true
-          rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
-      - uses: actions/checkout@v4
+      # - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
+      #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
+      #   run: |
+      #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
+      #       sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
+      #       echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
+      #     fi
+      # - name: Test some rosdep commands to see if the step above worked
+      #   run: |
+      #     rosdep update
+      #     echo "ROS_DISTRO: $ROS_DISTRO"
+      #     rosdep resolve test_msgs std_msgs || true
+      #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
+      # - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
       - uses: ros-tooling/action-ros-ci@0.3.7

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -7,18 +7,70 @@ on:
         required: true
         type: string
       os_name:
-        description: 'On which OS to run the workflow, e.g. ubuntu-22.04'
+        description: 'On which runner-OS to run the workflow, e.g. ubuntu-22.04'
         required: false
         default: 'ubuntu-latest'
+        type: string
+      container:
+        description: '(optional) Docker container to run the job in, e.g. ubuntu:noble'
+        required: false
+        default: ''
         type: string
 
 jobs:
   coverage:
     name: coverage build ${{ inputs.ros_distro }}
     runs-on: ${{ inputs.os_name }}
+    container: ${{ inputs.container }}
     steps:
+      - name: "Determine prerequisites"
+        id: prereq
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
+          apt install -y sudo apt-utils
+          echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+          echo "need_python=$(command -v python3 >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+          echo "need_rosdep=$(command -v rosdep >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+          echo "need_ros=$(if [ -d "/opt/ros/${{ inputs.ros_distro }}" ]; then echo 0; else echo 1; fi)" >> $GITHUB_OUTPUT
+
+      # needed for github actions, and only if a bare ubuntu image is used
+      # Consider switching to https://github.com/actions/setup-node when it works
+      # https://github.com/nektos/act/issues/973
+      # - uses: actions/setup-node@v4
+      #   if: ${{ steps.prereq.outputs.need_node == '1' }}
+      #   with:
+      #     node-version: 16
+      - name: Install node
+        if: ${{ steps.prereq.outputs.need_node == '1' }}
+        run: |
+          apt install -y curl
+          curl -sS https://webi.sh/node | sh
+          echo ~/.local/opt/node/bin >> $GITHUB_PATH
+
+      # not working for noble yet
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.11'
+      # needed only if a bare ubuntu image is used
+      - name: Install python
+        if: ${{ steps.prereq.outputs.need_python == '1' }}
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-pip
+
+      # why is this necessary for ros:rolling-ros-core-noble?
+      # and why does this not work with setup-ros?
+      - name: Install ros-dev-tools
+        if: ${{ steps.prereq.outputs.need_rosdep == '1' }}
+        run: |
+          apt install -y ros-dev-tools \
+          python3-colcon-common-extensions python3-colcon-mixin python3-colcon-coveragepy-result
+          rosdep init
+
+      # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
-      # - name: Temporary fix for rolling by setting the ROSDISTRO_INDEX_URL
+        if: ${{ steps.prereq.outputs.need_ros == '1' }}
+
+      # - name: Temporary fix for rolling@jammy by setting the ROSDISTRO_INDEX_URL
       #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
       #   run: |
       #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
@@ -31,7 +83,8 @@ jobs:
       #     echo "ROS_DISTRO: $ROS_DISTRO"
       #     rosdep resolve test_msgs std_msgs || true
       #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
-      # - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
       - uses: ros-tooling/action-ros-ci@0.3.7

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -39,21 +39,6 @@ jobs:
         # Consider switching to https://github.com/actions/setup-node when it works
         # https://github.com/nektos/act/issues/973
         if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
-
-        # - name: Temporary fix for rolling@jammy by setting the ROSDISTRO_INDEX_URL
-        #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
-        #   run: |
-        #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
-        #       sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
-        #       echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
-        #     fi
-        # - name: Test some rosdep commands to see if the step above worked
-        #   run: |
-        #     rosdep update
-        #     echo "ROS_DISTRO: $ROS_DISTRO"
-        #     rosdep resolve test_msgs std_msgs || true
-        #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
-
         run: |
           apt install -y curl
           curl -sS https://webi.sh/node | sh

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -29,61 +29,38 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
           apt install -y sudo apt-utils
           echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
-          echo "need_python=$(command -v python3 >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
-          echo "need_rosdep=$(command -v rosdep >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
-          echo "need_ros=$(if [ -d "/opt/ros/${{ inputs.ros_distro }}" ]; then echo 0; else echo 1; fi)" >> $GITHUB_OUTPUT
 
       # needed for github actions, and only if a bare ubuntu image is used
-      # Consider switching to https://github.com/actions/setup-node when it works
-      # https://github.com/nektos/act/issues/973
-      # - uses: actions/setup-node@v4
-      #   if: ${{ steps.prereq.outputs.need_node == '1' }}
-      #   with:
-      #     node-version: 16
+      - uses: actions/setup-node@v4
+        if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
+        # with:
+        #   node-version: 16
       - name: Install node
-        if: ${{ steps.prereq.outputs.need_node == '1' }}
+        # Consider switching to https://github.com/actions/setup-node when it works
+        # https://github.com/nektos/act/issues/973
+        if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
+
+        # - name: Temporary fix for rolling@jammy by setting the ROSDISTRO_INDEX_URL
+        #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
+        #   run: |
+        #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
+        #       sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
+        #       echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
+        #     fi
+        # - name: Test some rosdep commands to see if the step above worked
+        #   run: |
+        #     rosdep update
+        #     echo "ROS_DISTRO: $ROS_DISTRO"
+        #     rosdep resolve test_msgs std_msgs || true
+        #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
+
         run: |
           apt install -y curl
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 
-      # not working for noble yet
-      # - uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.11'
-      # needed only if a bare ubuntu image is used
-      - name: Install python
-        if: ${{ steps.prereq.outputs.need_python == '1' }}
-        run: |
-          DEBIAN_FRONTEND=noninteractive apt install -y python3-pip
-
-      # why is this necessary for ros:rolling-ros-core-noble?
-      # and why does this not work with setup-ros?
-      - name: Install ros-dev-tools
-        if: ${{ steps.prereq.outputs.need_rosdep == '1' }}
-        run: |
-          apt install -y ros-dev-tools \
-          python3-colcon-common-extensions python3-colcon-mixin python3-colcon-coveragepy-result
-          rosdep init
-
       # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
-        if: ${{ steps.prereq.outputs.need_ros == '1' }}
-
-      # - name: Temporary fix for rolling@jammy by setting the ROSDISTRO_INDEX_URL
-      #   # see https://docs.ros.org/en/rolling/How-To-Guides/Using-Custom-Rosdistro.html
-      #   run: |
-      #     if [[ "${{ inputs.ros_distro }}" == "rolling" ]]; then
-      #       sudo sed -i "s|ros\/rosdistro\/master|ros\/rosdistro\/rolling\/2024-02-28|" /etc/ros/rosdep/sources.list.d/20-default.list
-      #       echo "ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ros/rosdistro/rolling/2024-02-28/index-v4.yaml" >> $GITHUB_ENV
-      #     fi
-      # - name: Test some rosdep commands to see if the step above worked
-      #   run: |
-      #     rosdep update
-      #     echo "ROS_DISTRO: $ROS_DISTRO"
-      #     rosdep resolve test_msgs std_msgs || true
-      #     rosdep resolve test_msgs std_msgs --os=ubuntu:jammy --rosdistro=rolling
-
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -51,9 +51,16 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-3|${{ inputs.ros_distro }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Install system hooks and run pre-commit
+      - name: Install pre-commit and system hooks
+        shell: bash
         run: |
-          sudo apt-get install -qq ros-${{ inputs.ros_distro }}-ament-cppcheck ros-${{ inputs.ros_distro }}-ament-cpplint ros-${{ inputs.ros_distro }}-ament-lint-cmake ros-${{ inputs.ros_distro }}-ament-copyright
+          sudo apt-get install -qq ros-${{ inputs.ros_distro }}-ament-cppcheck ros-${{ inputs.ros_distro }}-ament-cpplint ros-${{ inputs.ros_distro }}-ament-lint-cmake ros-${{ inputs.ros_distro }}-ament-copyright python3-venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install pre-commit
+      - name: Run pre-commit
+        shell: bash
+        run: |
+          source .venv/bin/activate
           source /opt/ros/${{ inputs.ros_distro }}/setup.bash
-          python -m pip install pre-commit
           pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -24,6 +24,9 @@ jobs:
   pre-commit:
     runs-on: ${{ inputs.os_name }}
     container: ${{ inputs.container }}
+    env:
+      # this will be src/{repo-owner}/{repo-name}
+      path: src/${{ github.repository }}
     steps:
       - name: "Determine prerequisites"
         id: prereq
@@ -47,6 +50,9 @@ jobs:
       # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: ${{ env.path }}
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
@@ -63,4 +69,5 @@ jobs:
         run: |
           source .venv/bin/activate
           source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          cd ${{ env.path }}
           pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -14,20 +14,48 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+      container:
+        description: '(optional) Docker container to run the job in, e.g. ubuntu:noble'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   pre-commit:
     runs-on: ${{ inputs.os_name }}
+    container: ${{ inputs.container }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: ros-tooling/setup-ros@0.7.2
-    - uses: actions/cache@v4
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-3|${{ inputs.ros_distro }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - name: Install system hooks and run pre-commit
-      run: |
-        sudo apt-get install -qq ros-${{ inputs.ros_distro }}-ament-cppcheck ros-${{ inputs.ros_distro }}-ament-cpplint ros-${{ inputs.ros_distro }}-ament-lint-cmake ros-${{ inputs.ros_distro }}-ament-copyright
-        source /opt/ros/${{ inputs.ros_distro }}/setup.bash
-        python -m pip install pre-commit
-        pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual
+      - name: "Determine prerequisites"
+        id: prereq
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
+          apt install -y sudo apt-utils
+          echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+
+      # needed for github actions, and only if a bare ubuntu image is used
+      - uses: actions/setup-node@v4
+        if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
+        # with:
+        #   node-version: 16
+      - name: Install node
+        # Consider switching to https://github.com/actions/setup-node when it works
+        # https://github.com/nektos/act/issues/973
+        if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
+        run: |
+          apt install -y curl
+          curl -sS https://webi.sh/node | sh
+          echo ~/.local/opt/node/bin >> $GITHUB_PATH
+
+      # needed only if a non-ros image is used
+      - uses: ros-tooling/setup-ros@0.7.2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ inputs.ros_distro }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install system hooks and run pre-commit
+        run: |
+          sudo apt-get install -qq ros-${{ inputs.ros_distro }}-ament-cppcheck ros-${{ inputs.ros_distro }}-ament-cpplint ros-${{ inputs.ros_distro }}-ament-lint-cmake ros-${{ inputs.ros_distro }}-ament-copyright
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          python -m pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -35,8 +35,6 @@ jobs:
       # needed for github actions, and only if a bare ubuntu image is used
       - uses: actions/setup-node@v4
         if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
-        # with:
-        #   node-version: 16
       - name: Install node
         # Consider switching to https://github.com/actions/setup-node when it works
         # https://github.com/nektos/act/issues/973

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -31,8 +31,8 @@ jobs:
       - name: "Determine prerequisites"
         id: prereq
         run: |
-          DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
-          apt install -y sudo apt-utils
+          command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
+          DEBIAN_FRONTEND=noninteractive sudo apt update && sudo apt upgrade -y
           echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
 
       # needed for github actions, and only if a bare ubuntu image is used
@@ -43,7 +43,7 @@ jobs:
         # https://github.com/nektos/act/issues/973
         if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
         run: |
-          apt install -y curl
+          sudo apt install -y curl
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -41,8 +41,8 @@ jobs:
       - name: "Determine prerequisites"
         id: prereq
         run: |
-          DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
-          apt install -y sudo apt-utils
+          command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
+          DEBIAN_FRONTEND=noninteractive sudo apt update && sudo apt upgrade -y
           echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
 
       # needed for github actions, and only if a bare ubuntu image is used
@@ -53,7 +53,7 @@ jobs:
         # https://github.com/nektos/act/issues/973
         if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
         run: |
-          apt install -y curl
+          sudo apt install -y curl
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -48,8 +48,6 @@ jobs:
       # needed for github actions, and only if a bare ubuntu image is used
       - uses: actions/setup-node@v4
         if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
-        # with:
-        #   node-version: 16
       - name: Install node
         # Consider switching to https://github.com/actions/setup-node when it works
         # https://github.com/nektos/act/issues/973

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -23,18 +23,44 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
+      container:
+        description: '(optional) Docker container to run the job in, e.g. ubuntu:noble'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   reusable_ros_tooling_source_build:
     name: ${{ inputs.ros_distro }} ${{ inputs.os_name }}
     runs-on: ${{ inputs.os_name }}
+    container: ${{ inputs.container }}
     env:
       # this will be src/{repo-owner}/{repo-name}
       path: src/${{ github.repository }}
     steps:
+      - name: "Determine prerequisites"
+        id: prereq
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y
+          apt install -y sudo apt-utils
+          echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+
+      # needed for github actions, and only if a bare ubuntu image is used
+      - uses: actions/setup-node@v4
+        if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
+        # with:
+        #   node-version: 16
+      - name: Install node
+        # Consider switching to https://github.com/actions/setup-node when it works
+        # https://github.com/nektos/act/issues/973
+        if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
+        run: |
+          apt install -y curl
+          curl -sS https://webi.sh/node | sh
+          echo ~/.local/opt/node/bin >> $GITHUB_PATH
+
+      # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
-        with:
-          required-ros-distributions: ${{ inputs.ros_distro }}
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -48,7 +48,8 @@ jobs:
         if: steps.git_status.outputs.changed == 'true'
         run: |
           echo "Files have changed"
-          git diff --exit-code ${{ env.path }} || true
+          cd ${{ env.path }}
+          git diff --exit-code || true
 
       - name: No changes!
         if: steps.git_status.outputs.changed == 'false'

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -43,7 +43,7 @@ jobs:
         id: git_status
         run: |
           cd ${{ env.path }}
-          git diff --quiet ${{ env.path }} && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+          git diff --quiet && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: There are changes
         if: steps.git_status.outputs.changed == 'true'

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -42,12 +42,12 @@ jobs:
       - name: Check for changes
         id: git_status
         run: |
-          git diff --quiet ${{ env.path }} && echo "changed=false" >> $GITHUB_STATE || echo "changed=true" >> $GITHUB_STATE
+          cd ${{ env.path }}
+          git diff --quiet ${{ env.path }} && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: There are changes
         if: steps.git_status.outputs.changed == 'true'
         run: |
-          echo "Files have changed"
           cd ${{ env.path }}
           git diff --exit-code || true
 

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Check for changes
         id: git_status
         run: |
-          git diff --quiet && echo "::set-output name=changed::false" || echo "::set-output name=changed::true"
+          git diff --quiet ${{ env.path }} && echo "::set-output name=changed::false" || echo "::set-output name=changed::true"
 
       - name: There are changes
         if: steps.git_status.outputs.changed == 'true'
         run: |
           echo "Files have changed"
-          git diff --exit-code || true
+          git diff --exit-code ${{ env.path }} || true
 
       - name: No changes!
         if: steps.git_status.outputs.changed == 'false'
@@ -66,3 +66,4 @@ jobs:
           body: This pull request contains auto-updated files of the pre-commit config. @ros-controls/ros2-maintainers please run the pre-commit workflow manually on the branch `auto-update-${{ github.event.inputs.ref_for_scheduled_build }}` before merging.
           delete-branch: true
           draft: true
+          path: ${{ env.path }}

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -23,10 +23,14 @@ jobs:
 
       - name: Install pre-commit
         run: |
-          pip install pre-commit
+          sudo apt-get install -qq python3-venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install pre-commit
 
       - name: Auto-update with pre-commit
         run: |
+          source .venv/bin/activate
           pre-commit autoupdate || true  # Ignoring errors
 
       - name: Check for changes

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check for changes
         id: git_status
         run: |
-          git diff --quiet ${{ env.path }} && echo "::set-output name=changed::false" || echo "::set-output name=changed::true"
+          git diff --quiet ${{ env.path }} && echo "changed=false" >> $GITHUB_STATE || echo "changed=true" >> $GITHUB_STATE
 
       - name: There are changes
         if: steps.git_status.outputs.changed == 'true'

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -14,11 +14,16 @@ on:
 jobs:
   auto_update_and_create_pr:
     runs-on: ubuntu-latest
+    env:
+      # this will be src/{repo-owner}/{repo-name}
+      path: src/${{ github.repository }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
+          path: ${{ env.path }}
           ref: ${{ github.event.inputs.ref_for_scheduled_build }}
 
       - name: Install pre-commit
@@ -31,6 +36,7 @@ jobs:
       - name: Auto-update with pre-commit
         run: |
           source .venv/bin/activate
+          cd ${{ env.path }}
           pre-commit autoupdate || true  # Ignoring errors
 
       - name: Check for changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
 
   # CPP hooks
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.3
+    rev: v18.1.4
     hooks:
       - id: clang-format
         args: ['-fallback-style=none', '-i']


### PR DESCRIPTION
Using the last version of setup-ros fixed it for noble, if the correct container is used. These PR adds changes for all usages of setup-ros to make that work for our workflows.

Needs `container: ubuntu:24.04` until the github runner will be updated, but the workflows should work automatically if ubuntu-latest is bumped to 24.04 and no `container` input is given.

Fixes #51 and #13