### PR TITLE
Fix pre-commit cache

### DIFF
--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-3|${{ inputs.ros_distro }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit|${{ inputs.ros_distro }}|${{ hashFiles('${{ env.path }}/pre-commit-config.yaml') }}
       - name: Install pre-commit and system hooks
         shell: bash
         run: |

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ inputs.ros_distro }}|${{ hashFiles('${{ env.path }}/.pre-commit-config.yaml') }}
+          key: pre-commit|${{ inputs.ros_distro }}|${{ hashFiles( format('{0}/.pre-commit-config.yaml', env.path) ) }}
       - name: Install pre-commit and system hooks
         shell: bash
         run: |

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ inputs.ros_distro }}|${{ hashFiles('${{ env.path }}/pre-commit-config.yaml') }}
+          key: pre-commit|${{ inputs.ros_distro }}|${{ hashFiles('${{ env.path }}/.pre-commit-config.yaml') }}
       - name: Install pre-commit and system hooks
         shell: bash
         run: |


### PR DESCRIPTION
I changed the checkout path, but haven't updated the path for the hash function

`Cache restored from key: pre-commit|rolling|dc522a5d8b78c8cffc118fef77b9040b7e00a53dc32dc8c1d883cb88c641c9a0`