### PR TITLE
Use testing repo for setup-ros

### DIFF
--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -44,6 +44,8 @@ jobs:
 
       # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
+        with:
+          use-ros2-testing: true
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -49,6 +49,8 @@ jobs:
 
       # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
+        with:
+          use-ros2-testing: true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -59,6 +59,8 @@ jobs:
 
       # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.2
+        with:
+          use-ros2-testing: true
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}


### PR DESCRIPTION
(some?) core packages are already pre-released on testing repo for jazzy. Does it make sense to use testing as default for

- pre-commit
- coverage
- source

workflows? I think yes.