### PR TITLE
Coverage-build: Make repos file optional

### DIFF
--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           if [ -f ${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos ]; then
             echo "Local repos file found"
-            echo "repo_file=$(${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos)" >> $GITHUB_OUTPUT
+            echo "repo_file=${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos" >> $GITHUB_OUTPUT
           else
             echo "No local repos file found"
             echo "repo_file=" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -49,14 +49,23 @@ jobs:
       - uses: actions/checkout@v4
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
+      - name: Check for local repos file
+        id: check_local_repos
+        run: |
+          if [ -f ${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos ]; then
+            echo "Local repos file found"
+            echo "repo_file=$(${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos)" >> $GITHUB_OUTPUT
+          else
+            echo "No local repos file found"
+            echo "repo_file=" >> $GITHUB_OUTPUT
+          fi
       - uses: ros-tooling/action-ros-ci@0.3.7
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}
           import-token: ${{ secrets.GITHUB_TOKEN }}
           # build all packages listed here
           package-name: ${{ steps.package_list_action.outputs.package_list }}
-          vcs-repo-file-url: |
-            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos?token=${{ secrets.GITHUB_TOKEN }}
+          vcs-repo-file-url: ${{ steps.check_local_repos.outputs.repo_file }}
           colcon-defaults: |
             {
               "build": {


### PR DESCRIPTION
As with realtime_tools, there is no need for repos file because there are no dependencies, see the comment from @saikishor in https://github.com/ros-controls/realtime_tools/pull/165

All workflows do work without a repos file, except for the coverage build expecting a repos file for the distro in the main directory. I made that optional, without the need of changing all calling workflows by adding the repos file as inputs

Repo without repos file: https://github.com/ros-controls/realtime_tools/actions/runs/8878232544/job/24373456071
Repo with repos file: https://github.com/ros-controls/control_toolbox/actions/runs/8878352900/job/24374164258