### PR TITLE
Use official ros images for pre-commit

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -9,4 +9,3 @@ jobs:
     uses: ./.github/workflows/reusable-pre-commit.yml
     with:
       ros_distro: rolling
-      container: ubuntu:24.04

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -22,6 +22,7 @@ jobs:
         id: prereq
         run: |
           command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
+          sudo apt update
           echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
           echo "need_ros2=$(if [ -d "/opt/ros/${{ inputs.ros_distro }}" ]; then echo 0; else echo 1; fi)" >> $GITHUB_OUTPUT
 
@@ -33,7 +34,7 @@ jobs:
         # https://github.com/nektos/act/issues/973
         if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
         run: |
-          sudo apt update && sudo apt install -y curl
+          sudo apt install -y curl
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -9,21 +9,11 @@ on:
         description: 'ROS2 distribution name'
         required: true
         type: string
-      os_name:
-        description: 'On which OS to run the linter'
-        required: false
-        default: 'ubuntu-latest'
-        type: string
-      container:
-        description: '(optional) Docker container to run the job in, e.g. ubuntu:noble'
-        required: false
-        default: ''
-        type: string
 
 jobs:
   pre-commit:
-    runs-on: ${{ inputs.os_name }}
-    container: ${{ inputs.container }}
+    runs-on: ubuntu-latest
+    container: ros:${{ inputs.ros_distro }}
     env:
       # this will be src/{repo-owner}/{repo-name}
       path: src/${{ github.repository }}
@@ -32,8 +22,8 @@ jobs:
         id: prereq
         run: |
           command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
-          DEBIAN_FRONTEND=noninteractive sudo apt update && sudo apt upgrade -y
           echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+          echo "need_ros2=$(if [ -d "/opt/ros/${{ inputs.ros_distro }}" ]; then echo 0; else echo 1; fi)" >> $GITHUB_OUTPUT
 
       # needed for github actions, and only if a bare ubuntu image is used
       - uses: actions/setup-node@v4
@@ -43,14 +33,16 @@ jobs:
         # https://github.com/nektos/act/issues/973
         if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
         run: |
-          sudo apt install -y curl
+          sudo apt update && sudo apt install -y curl
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 
       # needed only if a non-ros image is used
       - uses: ros-tooling/setup-ros@0.7.3
+        if: ${{ steps.prereq.outputs.need_ros2 == '1' }}
         with:
           use-ros2-testing: true
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
As [ros:jazzy](https://discourse.ros.org/t/save-the-date-jazzy-jalisco-testing-and-tutorial-party-2024-05-01/37155/20) is available, we can use it and install ros only optionally -> way faster

Calling workflows do not fail if inputs are set which aren't available (no need to change every usage of reusable-pre-commit now).