### PR TITLE
gz compatibility < jazzy

### DIFF
--- a/ros_controls.rolling-on-humble.repos
+++ b/ros_controls.rolling-on-humble.repos
@@ -39,3 +39,19 @@ repositories:
     type: git
     url: https://github.com/gazebo-release/gz_plugin_vendor.git
     version: rolling
+  gz/gz_sim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sim_vendor.git
+    version: rolling
+  gz/gz_cmake_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_cmake_vendor.git
+    version: rolling
+  gz/gz_utils_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_utils_vendor.git
+    version: rolling
+  gz/gz_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_tools_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-humble.repos
+++ b/ros_controls.rolling-on-humble.repos
@@ -59,3 +59,47 @@ repositories:
     type: git
     url: https://github.com/gazebo-release/sdformat_vendor.git
     version: rolling
+  gz/gz_math_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_math_vendor.git
+    version: rolling
+  gz/gz_transport_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_transport_vendor.git
+    version: rolling
+  gz/gz_sensors_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sensors_vendor.git
+    version: rolling
+  gz/gz_msgs_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_msgs_vendor.git
+    version: rolling
+  gz/gz_common_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_common_vendor.git
+    version: rolling
+  gz/gz_rendering_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_rendering_vendor.git
+    version: rolling
+  gz/gz_ogre_next_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+    version: rolling
+  gz/gz_physics_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_physics_vendor.git
+    version: rolling
+  gz/gz_fuel_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+    version: rolling
+  gz/gz_gui_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_gui_vendor.git
+    version: rolling
+  gz/gz_dartsim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-humble.repos
+++ b/ros_controls.rolling-on-humble.repos
@@ -55,3 +55,7 @@ repositories:
     type: git
     url: https://github.com/gazebo-release/gz_tools_vendor.git
     version: rolling
+  gz/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-humble.repos
+++ b/ros_controls.rolling-on-humble.repos
@@ -35,3 +35,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
     version: master
+  gz/gz_plugin_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_plugin_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-iron.repos
+++ b/ros_controls.rolling-on-iron.repos
@@ -39,3 +39,19 @@ repositories:
     type: git
     url: https://github.com/gazebo-release/gz_plugin_vendor.git
     version: rolling
+  gz/gz_sim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sim_vendor.git
+    version: rolling
+  gz/gz_cmake_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_cmake_vendor.git
+    version: rolling
+  gz/gz_utils_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_utils_vendor.git
+    version: rolling
+  gz/gz_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_tools_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-iron.repos
+++ b/ros_controls.rolling-on-iron.repos
@@ -59,3 +59,47 @@ repositories:
     type: git
     url: https://github.com/gazebo-release/sdformat_vendor.git
     version: rolling
+  gz/gz_math_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_math_vendor.git
+    version: rolling
+  gz/gz_transport_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_transport_vendor.git
+    version: rolling
+  gz/gz_sensors_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sensors_vendor.git
+    version: rolling
+  gz/gz_msgs_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_msgs_vendor.git
+    version: rolling
+  gz/gz_common_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_common_vendor.git
+    version: rolling
+  gz/gz_rendering_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_rendering_vendor.git
+    version: rolling
+  gz/gz_ogre_next_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+    version: rolling
+  gz/gz_physics_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_physics_vendor.git
+    version: rolling
+  gz/gz_fuel_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+    version: rolling
+  gz/gz_gui_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_gui_vendor.git
+    version: rolling
+  gz/gz_dartsim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-iron.repos
+++ b/ros_controls.rolling-on-iron.repos
@@ -55,3 +55,7 @@ repositories:
     type: git
     url: https://github.com/gazebo-release/gz_tools_vendor.git
     version: rolling
+  gz/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: rolling

--- a/ros_controls.rolling-on-iron.repos
+++ b/ros_controls.rolling-on-iron.repos
@@ -35,3 +35,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
     version: master
+  gz/gz_plugin_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_plugin_vendor.git
+    version: rolling


### PR DESCRIPTION
I tried to manually pull all the non-released gz*vendor packages. 
Finally it fails with (not sure if this is the only one)
` gz_ogre_next_vendor: [libshaderc-dev] defined as "not available" for OS version [jammy]`

@azeey do you have a recommendation to fix this?
https://github.com/ros-controls/gz_ros2_control/pull/277#issuecomment-2099856853
Do I have to patch gz_ros2_control to add the dependencies before your PR? Will that work on jammy until humble+iron are EOL?