### PR TITLE
Deactivate gz_ros2_control compatibility build

### DIFF
--- a/ros_controls.rolling-on-humble.repos
+++ b/ros_controls.rolling-on-humble.repos
@@ -11,10 +11,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/gazebo_ros2_control.git
     version: master
-  ros-controls/gz_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+  # ros-controls/gz_ros2_control:
+  #   type: git
+  #   url: https://github.com/ros-controls/gz_ros2_control.git
+  #   version: master
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
@@ -27,10 +27,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
     version: master
-  ros-controls/ros2_control_demos:
-    type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
-    version: master
+  # ros-controls/ros2_control_demos:
+  #   type: git
+  #   url: https://github.com/ros-controls/ros2_control_demos.git
+  #   version: master
   ros-controls/ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git

--- a/ros_controls.rolling-on-iron.repos
+++ b/ros_controls.rolling-on-iron.repos
@@ -11,10 +11,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/gazebo_ros2_control.git
     version: master
-  ros-controls/gz_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+  # ros-controls/gz_ros2_control:
+  #   type: git
+  #   url: https://github.com/ros-controls/gz_ros2_control.git
+  #   version: master
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
@@ -27,10 +27,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
     version: master
-  ros-controls/ros2_control_demos:
-    type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
-    version: master
+  # ros-controls/ros2_control_demos:
+  #   type: git
+  #   url: https://github.com/ros-controls/ros2_control_demos.git
+  #   version: master
   ros-controls/ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
I'd suggest to deactivate the build of gz_ros2_control in the compatibility build until https://github.com/ros-controls/ros2_control_ci/pull/77 is fixed (which might be never), to test at least the core packages for compatibility.