### PR TITLE
Fix jazzy tests and other minor workflow changes

### DIFF
--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/humble-binary-build.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.humble.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -4,6 +4,10 @@ name: Humble Stack Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/humble-binary-build.yml'
+      - 'ros_controls.humble.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/iron-binary-build.yml
+++ b/.github/workflows/iron-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/iron-binary-build.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.iron.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/iron-binary-build.yml
+++ b/.github/workflows/iron-binary-build.yml
@@ -4,6 +4,10 @@ name: Iron Stack Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/iron-binary-build.yml'
+      - 'ros_controls.iron.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -4,6 +4,10 @@ name: Jazzy Stack Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/jazzy-binary-build.yml'
+      - 'ros_controls.jazzy.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/jazzy-binary-build.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.jazzy.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -1,5 +1,5 @@
-name: Rolling Stack Build
-# author: Denis Štogl <denis@stoglrobotics.de>
+name: Jazzy Stack Build
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
 # description: 'Build & test all dependencies from released (binary) packages.'
 
 on:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -4,6 +4,10 @@ name: Rolling Stack Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/rolling-binary-build.yml'
+      - 'ros_controls.rolling.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-binary-build.yml'
+      - './.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.rolling.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-compatibility-humble-binary-build.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.rolling-on-humble.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -4,6 +4,9 @@ name: Check Rolling Compatibility on Humble
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/rolling-compatibility-humble-binary-build.yml'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-compatibility-humble-binary-build.yml'
+      - 'ros_controls.rolling-on-humble.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-compatibility-iron-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-iron-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.rolling-on-iron.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/rolling-compatibility-iron-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-iron-binary-build.yml
@@ -4,6 +4,9 @@ name: Check Rolling Compatibility on Iron
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-compatibility-iron-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-iron-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
+      - 'ros_controls.rolling-on-iron.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
+      - 'ros_controls.rolling-on-jazzy.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -4,6 +4,9 @@ name: Check Rolling Compatibility on Jazzy
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.rolling-on-jazzy.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '.github/workflows/rolling-compatibility-iron-binary-build.yml'
+      - '.github/workflows/rolling-compatibility-jazzy-binary-build.yml'
       - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.rolling-on-jazzy.repos'
   schedule:

--- a/README.md
+++ b/README.md
@@ -9,13 +9,18 @@ It also builds the full ros2_control stack once per day.
 ## Released versions
 
 [![Rolling Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-binary-build.yml)
+
 [![Jazzy Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/jazzy-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/jazzy-binary-build.yml)
+
 [![Iron Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/iron-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/iron-binary-build.yml)
+
 [![Humble Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/humble-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/humble-binary-build.yml)
 
 ## Compatibility versions
 We thrive to make the rolling development version of the ros2_control stack compatible with earlier releases of ROS2. This is done by building the rolling version of the stack from source with the earlier releases of ROS2.
 
-[![Check Rolling Compatibility on Iron with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-iron-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-iron-binary-build.yml)
 [![Check Rolling Compatibility on Jazzy with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml)
+
+[![Check Rolling Compatibility on Iron with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-iron-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-iron-binary-build.yml)
+
 [![Check Rolling Compatibility on Humble with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml)

--- a/ros_controls.rolling-on-jazzy.repos
+++ b/ros_controls.rolling-on-jazzy.repos
@@ -7,10 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
     version: ros2-master
-  # ros-controls/gz_ros2_control:
-  #   type: git
-  #   url: https://github.com/ros-controls/gz_ros2_control.git
-  #   version: master
+  ros-controls/gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: master
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
@@ -23,10 +23,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
     version: master
-  # ros-controls/ros2_control_demos:
-  #   type: git
-  #   url: https://github.com/ros-controls/ros2_control_demos.git
-  #   version: master
+  ros-controls/ros2_control_demos:
+    type: git
+    url: https://github.com/ros-controls/ros2_control_demos.git
+    version: master
   ros-controls/ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git

--- a/ros_controls.rolling-on-jazzy.repos
+++ b/ros_controls.rolling-on-jazzy.repos
@@ -7,14 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
     version: ros2-master
-  ros-controls/gazebo_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gazebo_ros2_control.git
-    version: master
-  ros-controls/gz_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+  # ros-controls/gz_ros2_control:
+  #   type: git
+  #   url: https://github.com/ros-controls/gz_ros2_control.git
+  #   version: master
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
@@ -27,10 +23,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
     version: master
-  ros-controls/ros2_control_demos:
-    type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
-    version: master
+  # ros-controls/ros2_control_demos:
+  #   type: git
+  #   url: https://github.com/ros-controls/ros2_control_demos.git
+  #   version: master
   ros-controls/ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
- gazebo classic is not released on noble -> gazebo_ros2_control can't be compiled on jazzy/noble
- reformat README
- add path filters, run PRs if repos/yaml files have changed