### PR TITLE
Update reviewer-lottery.yml

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -20,7 +20,6 @@ groups:
       - DasRoteSkelett
       - erickisos
       - fmauch
-      - jaron-l
       - livanov93
       - mcbed
       - moriarty


### PR DESCRIPTION
jaron-l is not part of https://github.com/orgs/ros-controls/teams/ros2_control-reviewers (any more?), and I think this is why the job fails
https://github.com/ros-controls/ros2_controllers/actions/runs/9990514536/job/27611359952?pr=1220