### PR TITLE
gz_ros2_control: Use renamed rolling branch

### DIFF
--- a/ros_controls.rolling-on-jazzy.repos
+++ b/ros_controls.rolling-on-jazzy.repos
@@ -10,7 +10,7 @@ repositories:
   ros-controls/gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+    version: rolling
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -10,7 +10,7 @@ repositories:
   ros-controls/gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+    version: rolling
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
https://github.com/ros-controls/gz_ros2_control/pull/408#pullrequestreview-2260392863