### PR TITLE
Add a defaults.yaml file for source build

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -88,6 +88,7 @@ jobs:
             https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
             ${{ steps.check_local_repos.outputs.repo_file }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          colcon-defaults: https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/defaults.yaml
         id: action-ros
       - name: Download issue template for target failure  # Has to be a local file
         if: ${{ always() && steps.action-ros.outcome == 'failure' && github.event_name == 'schedule' }}

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "executor": "sequential"
+    }
+}


### PR DESCRIPTION
Test stage of source builds fail regularily, like https://github.com/ros-controls/ros2_controllers/issues/1299

The log is very confusing, then I realized that the action-ros-ci runs the tests in parallel, while ICI uses `--executor sequential` argument. I added a defaults yaml for the action-ros-ci, which should improve this

https://colcon.readthedocs.io/en/released/reference/executor-arguments.html
https://github.com/ros-tooling/action-ros-ci/blob/3e19c804cebf096f76de1b07ddd1cb52b5a2b8e3/action.yml#L8C3-L8C19
