### PR TITLE
Use ros images where possible

### DIFF
--- a/.github/workflows/reusable-abi-check.yml
+++ b/.github/workflows/reusable-abi-check.yml
@@ -1,0 +1,23 @@
+name: Reusable industrial_ci Workflow for ABI Compatibility Check
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS_DISTRO variable for industrial_ci'
+        required: true
+        type: string
+
+
+jobs:
+  reusable_abi-compatibility-ici:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ros-industrial/industrial_ci@master
+        env:
+          DOCKER_IMAGE: ghcr.io/sloretz/ros:${{ inputs.ros_distro }}-ros-base
+          ROS_REPO: main
+          ABICHECK_URL: github:${{ github.repository }}#${{ github.base_ref }}
+          NOT_TEST_BUILD: true

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -15,7 +15,7 @@ jobs:
   coverage:
     name: coverage build ${{ inputs.ros_distro }}
     runs-on: ubuntu-latest
-    container: ros:${{ inputs.ros_distro }}
+    container: ghcr.io/sloretz/ros:${{ inputs.ros_distro }}-ros-base
     defaults:
       run:
         shell: bash
@@ -40,9 +40,8 @@ jobs:
           curl -sS https://webi.sh/node | sh
           echo ~/.local/opt/node/bin >> $GITHUB_PATH
 
-      # needed only if a non-ros image is used
+      # overwrite ros distro with testing
       - uses: ros-tooling/setup-ros@0.7.9
-        if: ${{ steps.prereq.outputs.need_ros2 == '1' }}
         with:
           use-ros2-testing: true
       - name: Install coverage tools

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -39,11 +39,6 @@ on:
         default: ''
         required: false
         type: string
-      before_install_upstream_dependencies:
-        description: 'BEFORE_INSTALL_UPSTREAM_DEPENDENCIES variable for industrial_ci'
-        default: ''
-        required: false
-        type: string
       rosdep_skip_keys:
         description: 'ROSDEP_SKIP_KEYS variable for industrial_ci'
         default: ''
@@ -91,13 +86,12 @@ jobs:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
           TARGET_WORKSPACE: ${{ inputs.target_workspace }}
           DOWNSTREAM_WORKSPACE: ${{ inputs.downstream_workspace }}
-          ROS_DISTRO: ${{ inputs.ros_distro }}
+          DOCKER_IMAGE: ghcr.io/sloretz/ros:${{ inputs.ros_distro }}-ros-base
           ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}
-          BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
           ROSDEP_SKIP_KEYS: ${{ inputs.rosdep_skip_keys }}
         id: ici
-      - name: Download issue template  for target failure  # Has to be a local file
+      - name: Download issue template for target failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md

--- a/.github/workflows/reusable-rosdoc2.yml
+++ b/.github/workflows/reusable-rosdoc2.yml
@@ -7,15 +7,40 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    container: ros:rolling
     env:
       # this will be src/{repo-owner}/{repo-name}
       path: src/${{ github.repository }}
     steps:
-      - uses: ros-tooling/setup-ros@0.7.9
-      - name: Install rosdoc2 and deps
+      - name: "Determine prerequisites"
+        id: prereq
         run: |
-          sudo apt-get update
-          sudo apt install -y python3-pip git doxygen graphviz
+          command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
+          sudo apt update
+          echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+          echo "need_ros2=$(if [ -d "/opt/ros/${{ inputs.ros_distro }}" ]; then echo 0; else echo 1; fi)" >> $GITHUB_OUTPUT
+
+      # needed for github actions, and only if a bare ubuntu image is used
+      - uses: actions/setup-node@v4
+        if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
+      - name: Install node
+        # Consider switching to https://github.com/actions/setup-node when it works
+        # https://github.com/nektos/act/issues/973
+        if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
+        run: |
+          sudo apt install -y curl
+          curl -sS https://webi.sh/node | sh
+          echo ~/.local/opt/node/bin >> $GITHUB_PATH
+
+      # needed only if a non-ros image is used
+      - uses: ros-tooling/setup-ros@0.7.9
+        if: ${{ steps.prereq.outputs.need_ros2 == '1' }}
+        with:
+          use-ros2-testing: true
+      - name: Install rosdoc2 and deps
+        shell: bash
+        run: |
+          sudo apt install -y python3-pip python3-venv git doxygen graphviz
           python3 -m venv .venv
           source .venv/bin/activate
           pip install Sphinx
@@ -30,6 +55,7 @@ jobs:
         with:
           path: ${{ env.path }}
       - name: run rosdoc2
+        shell: bash
         run: |
           source .venv/bin/activate
           for path in ${{ steps.package_list_action.outputs.package_path_list }}


### PR DESCRIPTION
- add a reusable workflow for ABI check (and use https://github.com/sloretz/ros_oci_images/)
- coverage-build: use https://github.com/sloretz/ros_oci_images/ and always use testing branch
- ici (used for binary and semi-binary builds): use https://github.com/sloretz/ros_oci_images/
- rosdoc2: Use ros:rolling instead of bare ubuntu image

This saves a minute here and there, especially when using `act` locally when the docker images are pulled already.

Tested with https://github.com/ros-controls/control_toolbox/pull/216