### PR TITLE
Run test-result if colcon test failed

### DIFF
--- a/.github/workflows/reusable-debian-build.yml
+++ b/.github/workflows/reusable-debian-build.yml
@@ -68,7 +68,6 @@ jobs:
           colcon build --packages-up-to ${{ steps.package_list_action.outputs.package_list }} --packages-skip ${{ inputs.skip_packages }}
       - name: Test workspace
         shell: bash
-        continue-on-error: false
         run: |
           source /opt/ros2_ws/install/setup.bash
           colcon test --packages-select ${{ steps.package_list_action.outputs.package_list }} --packages-skip ${{ inputs.skip_packages }} ${{ inputs.skip_packages_test }}

--- a/.github/workflows/reusable-rhel-binary-build.yml
+++ b/.github/workflows/reusable-rhel-binary-build.yml
@@ -77,7 +77,6 @@ jobs:
           colcon build --packages-up-to ${{ steps.package_list_action.outputs.package_list }} --packages-skip ${{ inputs.skip_packages }}
       - name: Test workspace
         shell: bash
-        continue-on-error: false
         run: |
           source /opt/ros/${{ inputs.ros_distro }}/setup.bash
           source /opt/ros2_ws/install/local_setup.bash


### PR DESCRIPTION
We don't get the error logs from `colcon test-result`, see this job https://github.com/ros-controls/ros2_control/actions/runs/11710512553/attempts/2

`continue-on-error` is not well documented, but maybe this is why it doesn't complete the run steps.