### PR TITLE
Add reusable workflow for windows CI

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -9,9 +9,10 @@ on:
           https://github.com/ros-tooling/setup-ros/blob/master/src/setup-ros-windows.ts'
         required: true
         type: string
-      ref:
-        description: 'Reference on which the repo should be checkout. Usually is this name of a branch or a tag.'
-        required: true
+      ref_for_scheduled_build:
+        description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
         type: string
       os_name:
         description: 'On which OS to run the build job'
@@ -71,10 +72,19 @@ jobs:
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
           use-ros2-testing: true
-      - uses: actions/checkout@v4
+
+      - name: Checkout default ref when build is not scheduled
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
           path: ${{ env.repo_path }}
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref_for_scheduled_build }}
+          path: ${{ env.repo_path }}
+
       - id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
         with:

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -34,46 +34,50 @@ jobs:
       # this will be src/{repo-owner}/{repo-name}
       repo_path: src/${{ github.repository }}
     steps:
-      - name: Set python version paths
-        # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
-        # * setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
-        # * whatever we do here, python 3.12 is selected in the action-ros-ci step
-        # https://github.com/ros2/ros2/issues/1430#issuecomment-1634580503
-        # https://github.com/ros-tooling/setup-ros/issues/552#issuecomment-1551872040
-        # -> the only working solution I've found is to remove the other python versions
-        run: |
-          # Base path where Python versions are stored
-          $basePath = "C:/hostedtoolcache/windows/Python/"
+      # - name: Set python version paths
+      #   # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
+      #   # * setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
+      #   # * whatever we do here, python 3.12 is selected in the action-ros-ci step
+      #   # https://github.com/ros2/ros2/issues/1430#issuecomment-1634580503
+      #   # https://github.com/ros-tooling/setup-ros/issues/552#issuecomment-1551872040
+      #   # -> the only working solution I've found is to remove the other python versions
+      #   run: |
+      #     # Base path where Python versions are stored
+      #     $basePath = "C:/hostedtoolcache/windows/Python/"
 
-          # Find the first matching folder for 3.8.*
-          $pythonFolder = Get-ChildItem -Path $basePath -Filter "3.8.*" -Directory | Select-Object -First 1
-          if ($pythonFolder) {
-            $pythonVer = $pythonFolder.Name
-            $newPath = "$basePath\$pythonVer\x64;$basePath\$pythonVer\x64\Scripts;$env:PATH"
-            # Update environment variables
-            Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
-            Add-Content -Path $env:GITHUB_ENV -Value "Python3_ROOT_DIR=$basePath\$pythonVer"
-            Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$basePath\$pythonVer\x64"
-            Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$basePath\$pythonVer\x64\lib"
-            Write-Host "Python version set to: $pythonVer"
-          } else {
-              Write-Error "No Python 3.8.* version found in $basePath"
-          }
-          Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_STRATEGY=LOCATION"
-          Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_REGISTRY=NEVER"
-          Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON=3"
-          Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON3=3.8"
+      #     # Find the first matching folder for 3.8.*
+      #     $pythonFolder = Get-ChildItem -Path $basePath -Filter "3.8.*" -Directory | Select-Object -First 1
+      #     if ($pythonFolder) {
+      #       $pythonVer = $pythonFolder.Name
+      #       $newPath = "$basePath\$pythonVer\x64;$basePath\$pythonVer\x64\Scripts;$env:PATH"
+      #       # Update environment variables
+      #       Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
+      #       Add-Content -Path $env:GITHUB_ENV -Value "Python3_ROOT_DIR=$basePath\$pythonVer"
+      #       Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$basePath\$pythonVer\x64"
+      #       Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$basePath\$pythonVer\x64\lib"
+      #       Write-Host "Python version set to: $pythonVer"
+      #     } else {
+      #         Write-Error "No Python 3.8.* version found in $basePath"
+      #     }
+      #     Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_STRATEGY=LOCATION"
+      #     Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_REGISTRY=NEVER"
+      #     Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON=3"
+      #     Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON3=3.8"
 
-          # List of specific version patterns to match
-          $versionPatterns = @("3.12.*", "3.11.*", "3.10.*", "3.9.*")
-          # Loop through each pattern and remove matching directories
-          foreach ($pattern in $versionPatterns) {
-              $matchingPaths = Get-ChildItem -Path $basePath -Filter $pattern -Directory -ErrorAction SilentlyContinue
-              foreach ($path in $matchingPaths) {
-                  Remove-Item -Recurse -Force $path.FullName
-                  Write-Host "Deleted: $($path.FullName)"
-              }
-          }
+      #     # List of specific version patterns to match
+      #     $versionPatterns = @("3.12.*", "3.11.*", "3.10.*", "3.9.*")
+      #     # Loop through each pattern and remove matching directories
+      #     foreach ($pattern in $versionPatterns) {
+      #         $matchingPaths = Get-ChildItem -Path $basePath -Filter $pattern -Directory -ErrorAction SilentlyContinue
+      #         foreach ($path in $matchingPaths) {
+      #             Remove-Item -Recurse -Force $path.FullName
+      #             Write-Host "Deleted: $($path.FullName)"
+      #         }
+      #     }
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
 
       - name: Check python version
         # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
@@ -119,6 +123,10 @@ jobs:
             Write-Output "No local repos file found"
             "repo_file=" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
           }
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
 
       - uses: ros-tooling/action-ros-ci@0.3.15
         with:

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -37,11 +37,10 @@ jobs:
       - name: Set python version paths
         # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
         # * setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
-        # * whatever we do here, python 3.12 is selected by action-ros-ci
+        # * whatever we do here, python 3.12 is selected in the action-ros-ci step
         # https://github.com/ros2/ros2/issues/1430#issuecomment-1634580503
+        # https://github.com/ros-tooling/setup-ros/issues/552#issuecomment-1551872040
         # -> the only working solution I've found is to remove the other python versions
-        # action-ros-ci uses cmd.exe -> Git\bin\bash.exe, which gives the correct version here, but
-        # ament_cmake is always finding the newest python version -> dependencies are not installed
         run: |
           # Base path where Python versions are stored
           $basePath = "C:/hostedtoolcache/windows/Python/"
@@ -76,9 +75,10 @@ jobs:
               }
           }
 
-
       - name: Check python version
         # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
+        # action-ros-ci uses cmd.exe -> Git\bin\bash.exe, which gives the correct version here, but
+        # ament_cmake is always finding the newest python version -> dependencies are not installed
         run: |
           python3 --version || true
           python --version || true

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -1,0 +1,124 @@
+name: Reusable Windows Binary Build
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS 2 distribution name. One of
+          https://github.com/ros-tooling/setup-ros/blob/master/src/setup-ros-windows.ts'
+        required: true
+        type: string
+      ref:
+        description: 'Reference on which the repo should be checkout. Usually is this name of a branch or a tag.'
+        required: true
+        type: string
+      os_name:
+        description: 'On which OS to run the build job'
+        required: false
+        default: 'windows-2019'
+        type: string
+      container:
+        description: '(optional) Docker container to run the job in, e.g. ubuntu:noble'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  reusable_ros_tooling_source_build:
+    name: ${{ inputs.ros_distro }} ${{ inputs.os_name }}
+    runs-on: ${{ inputs.os_name }}
+    container: ${{ inputs.container }}
+    env:
+      # this will be src/{repo-owner}/{repo-name}
+      repo_path: src/${{ github.repository }}
+      python_ver: 3.8.10
+    steps:
+      - name: Check python version and set paths
+        # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
+        # * setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
+        # * whatever we do here, python 3.12 is selected by action-ros-ci
+        # https://github.com/ros2/ros2/issues/1430#issuecomment-1634580503
+        # -> the only working solution I've found is to remove the other python versions
+        # action-ros-ci uses cmd.exe -> Git\bin\bash.exe, which gives the correct version here, but
+        # ament_cmake is always finding the newest python version -> dependencies are not installed
+        run: |
+          $newPath = "C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64;C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64\Scripts;$env:PATH"
+          Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
+          Add-Content -Path $env:GITHUB_ENV -Value "Python3_ROOT_DIR=C:\hostedtoolcache\windows\Python\${{ env.python_ver }}"
+          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64"
+          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64\lib"
+          Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_STRATEGY=LOCATION"
+          Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_REGISTRY=NEVER"
+          Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON=3"
+          Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON3=3.8"
+          python3 --version || true
+          python --version || true
+          pip3 --version || true
+          pip --version || true
+          C:\Windows\system32\cmd.exe /E:ON /V:OFF /S /C call "C:\Program Files\Git\bin\bash.exe" -c "python3 --version" || true
+          C:\Windows\system32\cmd.exe /E:ON /V:OFF /S /C call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && & "C:\Program Files\Git\bin\bash.exe" -c "python3 --version" || true
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.12.7"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.11.9"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.10.11"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.9.13"
+
+      - uses: ros-tooling/setup-ros@0.7.9
+        with:
+          required-ros-distributions: ${{ inputs.ros_distro }}
+          use-ros2-testing: true
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: ${{ env.repo_path }}
+      - id: package_list_action
+        uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
+        with:
+          path: ${{ env.repo_path }}
+
+      - name: Check for local repos file
+        id: check_local_repos
+        run: |
+          if (Test-Path ${{ env.repo_path }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos) {
+              Write-Output "Local repos file found"
+              "repo_file=${{ env.repo_path }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Output "No local repos file found"
+            "repo_file=" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          }
+
+      - uses: ros-tooling/action-ros-ci@0.3.15
+        with:
+          target-ros2-distro: ${{ inputs.ros_distro }}
+          ref: ${{ inputs.ref }}
+          package-name: ${{ steps.package_list_action.outputs.package_list }}
+          vcs-repo-file-url: |
+            ${{ steps.check_local_repos.outputs.repo_file }}
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          colcon-defaults: |
+            {
+                "test": {
+                    "executor": "sequential"
+                }
+            }
+        id: action-ros
+
+      - name: Download issue template for target failure  # Has to be a local file
+        if: ${{ always() && steps.action-ros.outcome == 'failure' && github.event_name == 'schedule' }}
+        run:
+          wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O ${{ env.repo_path }}/.github/issue_template_failed_ci.md
+      - uses: JasonEtco/create-an-issue@v2
+        # action-ros-ci does not report more details on test failures afaik
+        if: ${{ always() && steps.action-ros.outcome == 'failure' && github.event_name == 'schedule'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION_NAME: ${{ inputs.ros_distro }}/source
+          REF: ${{ inputs.ref }}
+          URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: ${{ env.repo_path }}/.github/issue_template_failed_ci.md
+      - uses: actions/upload-artifact@v4.4.3
+        with:
+          name: colcon-logs-${{ inputs.os_name }}-${{ inputs.ros_distro }}
+          path: ros_ws/log

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -33,7 +33,6 @@ jobs:
     env:
       # this will be src/{repo-owner}/{repo-name}
       repo_path: src/${{ github.repository }}
-      python_ver: 3.8.10
     steps:
       - name: Set python version paths
         # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
@@ -44,19 +43,39 @@ jobs:
         # action-ros-ci uses cmd.exe -> Git\bin\bash.exe, which gives the correct version here, but
         # ament_cmake is always finding the newest python version -> dependencies are not installed
         run: |
-          $newPath = "C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64;C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64\Scripts;$env:PATH"
-          Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
-          Add-Content -Path $env:GITHUB_ENV -Value "Python3_ROOT_DIR=C:\hostedtoolcache\windows\Python\${{ env.python_ver }}"
-          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64"
-          Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=C:\hostedtoolcache\windows\Python\${{ env.python_ver }}\x64\lib"
+          # Base path where Python versions are stored
+          $basePath = "C:/hostedtoolcache/windows/Python/"
+
+          # Find the first matching folder for 3.8.*
+          $pythonFolder = Get-ChildItem -Path $basePath -Filter "3.8.*" -Directory | Select-Object -First 1
+          if ($pythonFolder) {
+            $pythonVer = $pythonFolder.Name
+            $newPath = "$basePath\$pythonVer\x64;$basePath\$pythonVer\x64\Scripts;$env:PATH"
+            # Update environment variables
+            Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
+            Add-Content -Path $env:GITHUB_ENV -Value "Python3_ROOT_DIR=$basePath\$pythonVer"
+            Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$basePath\$pythonVer\x64"
+            Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$basePath\$pythonVer\x64\lib"
+            Write-Host "Python version set to: $pythonVer"
+          } else {
+              Write-Error "No Python 3.8.* version found in $basePath"
+          }
           Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_STRATEGY=LOCATION"
           Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_REGISTRY=NEVER"
           Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON=3"
           Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON3=3.8"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.12.7"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.11.9"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.10.11"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.9.13"
+
+          # List of specific version patterns to match
+          $versionPatterns = @("3.12.*", "3.11.*", "3.10.*", "3.9.*")
+          # Loop through each pattern and remove matching directories
+          foreach ($pattern in $versionPatterns) {
+              $matchingPaths = Get-ChildItem -Path $basePath -Filter $pattern -Directory -ErrorAction SilentlyContinue
+              foreach ($path in $matchingPaths) {
+                  Remove-Item -Recurse -Force $path.FullName
+                  Write-Host "Deleted: $($path.FullName)"
+              }
+          }
+
 
       - name: Check python version
         # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -34,62 +34,11 @@ jobs:
       # this will be src/{repo-owner}/{repo-name}
       repo_path: src/${{ github.repository }}
     steps:
-      # - name: Set python version paths
-      #   # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
-      #   # * setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
-      #   # * whatever we do here, python 3.12 is selected in the action-ros-ci step
-      #   # https://github.com/ros2/ros2/issues/1430#issuecomment-1634580503
-      #   # https://github.com/ros-tooling/setup-ros/issues/552#issuecomment-1551872040
-      #   # -> the only working solution I've found is to remove the other python versions
-      #   run: |
-      #     # Base path where Python versions are stored
-      #     $basePath = "C:/hostedtoolcache/windows/Python/"
-
-      #     # Find the first matching folder for 3.8.*
-      #     $pythonFolder = Get-ChildItem -Path $basePath -Filter "3.8.*" -Directory | Select-Object -First 1
-      #     if ($pythonFolder) {
-      #       $pythonVer = $pythonFolder.Name
-      #       $newPath = "$basePath\$pythonVer\x64;$basePath\$pythonVer\x64\Scripts;$env:PATH"
-      #       # Update environment variables
-      #       Add-Content -Path $env:GITHUB_ENV -Value "PATH=$newPath"
-      #       Add-Content -Path $env:GITHUB_ENV -Value "Python3_ROOT_DIR=$basePath\$pythonVer"
-      #       Add-Content -Path $env:GITHUB_ENV -Value "PYTHONHOME=$basePath\$pythonVer\x64"
-      #       Add-Content -Path $env:GITHUB_ENV -Value "PYTHONPATH=$basePath\$pythonVer\x64\lib"
-      #       Write-Host "Python version set to: $pythonVer"
-      #     } else {
-      #         Write-Error "No Python 3.8.* version found in $basePath"
-      #     }
-      #     Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_STRATEGY=LOCATION"
-      #     Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_REGISTRY=NEVER"
-      #     Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON=3"
-      #     Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON3=3.8"
-
-      #     # List of specific version patterns to match
-      #     $versionPatterns = @("3.12.*", "3.11.*", "3.10.*", "3.9.*")
-      #     # Loop through each pattern and remove matching directories
-      #     foreach ($pattern in $versionPatterns) {
-      #         $matchingPaths = Get-ChildItem -Path $basePath -Filter $pattern -Directory -ErrorAction SilentlyContinue
-      #         foreach ($path in $matchingPaths) {
-      #             Remove-Item -Recurse -Force $path.FullName
-      #             Write-Host "Deleted: $($path.FullName)"
-      #         }
-      #     }
-
       - uses: actions/setup-python@v5
+        # setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
+        # let's use the same version here for the later action-ros-ci step
         with:
           python-version: '3.8'
-
-      - name: Check python version
-        # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
-        # action-ros-ci uses cmd.exe -> Git\bin\bash.exe, which gives the correct version here, but
-        # ament_cmake is always finding the newest python version -> dependencies are not installed
-        run: |
-          python3 --version || true
-          python --version || true
-          pip3 --version || true
-          pip --version || true
-          C:\Windows\system32\cmd.exe /E:ON /V:OFF /S /C call "C:\Program Files\Git\bin\bash.exe" -c "python3 --version" || true
-          C:\Windows\system32\cmd.exe /E:ON /V:OFF /S /C call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && & "C:\Program Files\Git\bin\bash.exe" -c "python3 --version" || true
 
       - uses: ros-tooling/setup-ros@0.7.9
         with:

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -34,7 +34,7 @@ jobs:
       repo_path: src/${{ github.repository }}
       python_ver: 3.8.10
     steps:
-      - name: Check python version and set paths
+      - name: Set python version paths
         # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
         # * setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
         # * whatever we do here, python 3.12 is selected by action-ros-ci
@@ -52,16 +52,20 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "Python3_FIND_REGISTRY=NEVER"
           Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON=3"
           Add-Content -Path $env:GITHUB_ENV -Value "PY_PYTHON3=3.8"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.12.7"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.11.9"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.10.11"
+          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.9.13"
+
+      - name: Check python version
+        # TODO(anyone): remove this step once the setup-ros/action-ros-ci is fixed
+        run: |
           python3 --version || true
           python --version || true
           pip3 --version || true
           pip --version || true
           C:\Windows\system32\cmd.exe /E:ON /V:OFF /S /C call "C:\Program Files\Git\bin\bash.exe" -c "python3 --version" || true
           C:\Windows\system32\cmd.exe /E:ON /V:OFF /S /C call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && & "C:\Program Files\Git\bin\bash.exe" -c "python3 --version" || true
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.12.7"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.11.9"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.10.11"
-          Remove-Item -Recurse -Force "C:/hostedtoolcache/windows/Python/3.9.13"
 
       - uses: ros-tooling/setup-ros@0.7.9
         with:

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -123,7 +123,6 @@ jobs:
       - uses: ros-tooling/action-ros-ci@0.3.15
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}
-          ref: ${{ inputs.ref }}
           package-name: ${{ steps.package_list_action.outputs.package_list }}
           vcs-repo-file-url: |
             ${{ steps.check_local_repos.outputs.repo_file }}
@@ -146,12 +145,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/source
-          REF: ${{ inputs.ref }}
+          REF: ${{ inputs.ref_for_scheduled_build }}
           URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           update_existing: true
           filename: ${{ env.repo_path }}/.github/issue_template_failed_ci.md
-      - uses: actions/upload-artifact@v4.4.3
-        with:
-          name: colcon-logs-${{ inputs.os_name }}-${{ inputs.ros_distro }}
-          path: ros_ws/log


### PR DESCRIPTION
- setup-ros has hardcoded python 3.8, as it is the default version acc. to REP-2000 for jazzy
- whatever I tried, python 3.12 is selected by action-ros-ci
- action-ros-ci uses cmd.exe -> Git\bin\bash.exe, which gives the correct version in the first step, but
- ament_cmake is always finding the newest python version -> dependencies are not installed

See also https://github.com/ros2/ros2/issues/1430#issuecomment-1634580503

--> the only working solution I've found is to remove the other python versions first.