### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     rev: v3.19.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py39-plus]
 
   # PyDocStyle
   - repo: https://github.com/PyCQA/pydocstyle


### PR DESCRIPTION
reorder-python-imports will replace imports which were moved out of the typing module in pep 585.