### PR TITLE
Mark everything under /opt/ros a system header

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -118,7 +118,7 @@ jobs:
           ADDITIONAL_DEBS: ${{ inputs.additional_debs }}
           CC: ${{ inputs.c_compiler }}
           CXX: ${{ inputs.cxx_compiler }}
-          CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-isystem /opt/ros/${{ inputs.ros_distro }}/include
+          CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-isystem /opt/ros/${{ inputs.ros_distro }}/include"
         id: ici
       - name: Download issue template for target failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -118,6 +118,7 @@ jobs:
           ADDITIONAL_DEBS: ${{ inputs.additional_debs }}
           CC: ${{ inputs.c_compiler }}
           CXX: ${{ inputs.cxx_compiler }}
+          CMAKE_ARGS: -DCMAKE_CXX_FLAGS=-isystem /opt/ros/${{ inputs.ros_distro }}/include
         id: ici
       - name: Download issue template for target failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}


### PR DESCRIPTION
We had warnings from upstream packages passing to our builds, resulting in [clang jobs to fail](https://github.com/ros-controls/ros2_control/actions/runs/12244504697/job/34156383141?pr=1918)

I propose excluding all system headers from these checks

see https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-in-system-headers