### PR TITLE
Add docker files for debian and rhel

### DIFF
--- a/.github/workflows/build_and_publish_debian_docker.yaml
+++ b/.github/workflows/build_and_publish_debian_docker.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 1 * * MON'
 
 jobs:
-  build_images_debian11:
+  build_images:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,7 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro: ['humble']
+        include:
+          - ros_distro: 'humble'
+            debian_version: 'debian11'
+          - ros_distro: 'jazzy'
+            debian_version: 'debian12'
+          - ros_distro: 'rolling'
+            debian_version: 'debian12'
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -32,32 +38,7 @@ jobs:
         with:
           context: ros2_debian
           push: true
-          file: Dockerfile.debian11
-          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian
-          build-args: |
-            ROS_DISTRO=${{ matrix.ros_distro }}
-  build_images_debian12:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        ros_distro: ['jazzy', 'rolling']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ros2_debian
-          push: true
-          file: Dockerfile.debian12
+          file: Dockerfile.${{ matrix.debian_version }}
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_publish_debian_docker.yaml
+++ b/.github/workflows/build_and_publish_debian_docker.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           context: ros2_debian
           push: true
-          file: Dockerfile.${{ matrix.debian_version }}
+          file: ros2_debian/Dockerfile.${{ matrix.debian_version }}
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_publish_debian_docker.yaml
+++ b/.github/workflows/build_and_publish_debian_docker.yaml
@@ -30,6 +30,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
+          context: ros2_debian
           push: true
           file: Dockerfile.debian11
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian
@@ -54,6 +55,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
+          context: ros2_debian
           push: true
           file: Dockerfile.debian12
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian

--- a/.github/workflows/build_and_publish_debian_docker.yaml
+++ b/.github/workflows/build_and_publish_debian_docker.yaml
@@ -1,0 +1,61 @@
+---
+name: Build and publish debian docker images
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/build_and_publish_debian_docker.yaml'
+      - 'ros2_debian/**'
+  schedule:
+    - cron: '0 1 * * MON'
+
+jobs:
+  build_images_debian11:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: ['humble']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile.debian11
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+  build_images_debian12:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: ['jazzy', 'rolling']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile.debian12
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-debian
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -30,6 +30,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
+          context: ros2_rhel
           push: true
           file: Dockerfile.rhel8
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
@@ -54,6 +55,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
+          context: ros2_rhel
           push: true
           file: Dockerfile.rhel9
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel

--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -1,5 +1,5 @@
 ---
-name: build and publish rhel docker images
+name: Build and publish RHEL docker images
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -1,0 +1,61 @@
+---
+name: build and publish rhel docker images
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/build_and_publish_rhel_docker.yaml'
+      - 'ros2_rhel/**'
+  schedule:
+    - cron: '1 0 * * MON'
+
+jobs:
+  build_images_rhel8:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: ['humble']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile.rhel8
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+  build_images_rhel9:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: ['jazzy', 'rolling']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile.rhel9
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '1 0 * * MON'
 
 jobs:
-  build_images_rhel8:
+  build_images:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,7 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro: ['humble']
+        include:
+          - ros_distro: 'humble'
+            rhel_version: 'rhel8'
+          - ros_distro: 'jazzy'
+            rhel_version: 'rhel9'
+          - ros_distro: 'rolling'
+            rhel_version: 'rhel9'
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -32,32 +38,7 @@ jobs:
         with:
           context: ros2_rhel
           push: true
-          file: Dockerfile.rhel8
-          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
-          build-args: |
-            ROS_DISTRO=${{ matrix.ros_distro }}
-  build_images_rhel9:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        ros_distro: ['jazzy', 'rolling']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ros2_rhel
-          push: true
-          file: Dockerfile.rhel9
+          file: ros2_rhel/Dockerfile.${{ matrix.rhel_version }}
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-rhel
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,7 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: ['--write-changes']
+        args: ['--write-changes', '-L empy']
         exclude: CHANGELOG\.rst|\.(svg|pyc)$
 
   - repo: https://github.com/python-jsonschema/check-jsonschema

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This repository holds reusable workflows for CI of the ros2_control framework as well as docker images for building the ros2_control stack on different platforms.
+This repository holds reusable workflows for CI of the ros2_control framework as well as docker images for building the ros2_control stack on different platforms, supporting all current releases as by [REP-2000](https://ros.org/reps/rep-2000.html).
 
 It also builds the full ros2_control stack once per day.
 
@@ -25,8 +25,6 @@ We thrive to make the rolling development version of the ros2_control stack comp
 This is a sample Dockerfile that show ros2 installed on almalinux based on the [binary installation instructions at docs.ros.org](https://docs.ros.org/en/rolling/Installation/RHEL-Install-RPMs.html). The most recent public build can be found with the docker tag: `ghcr.io/ros-controls/ros:<ROS_DISTRO>-rhel` where `<ROS_DISTRO>` is replaced with the ros distribution you are targeting.
 
 The image tries to emulate the official ros2 images but on alma (downstream RHEL) linux. Therefore a few extra packages can be found within this repo that are not mentioned at the above link, i.e. colcon, etc.
-
-Only supports galactic and later releases as that is what the [ros2 buildfarm supports for RHEL](https://ros.org/reps/rep-2000.html#galactic-geochelone-may-2021-november-2022).
 
 ## ros2_debian
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ros2_control_ci
 
-[![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This repository holds reusable workflows for CI of the ros2_control framework.
+This repository holds reusable workflows for CI of the ros2_control framework as well as docker images for building the ros2_control stack on different platforms.
 
 It also builds the full ros2_control stack once per day.
 
@@ -20,3 +20,29 @@ We thrive to make the rolling development version of the ros2_control stack comp
 [![Check Rolling Compatibility on Jazzy with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml)
 
 [![Check Rolling Compatibility on Humble with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml)
+
+## ros2_rhel
+This is a sample Dockerfile that show ros2 installed on almalinux based on the [binary installation instructions at docs.ros.org](https://docs.ros.org/en/rolling/Installation/RHEL-Install-RPMs.html). The most recent public build can be found with the docker tag: `ghcr.io/ros-controls/ros:<ROS_DISTRO>-rhel` where `<ROS_DISTRO>` is replaced with the ros distribution you are targeting.
+
+The image tries to emulate the official ros2 images but on alma (downstream RHEL) linux. Therefore a few extra packages can be found within this repo that are not mentioned at the above link, i.e. colcon, etc.
+
+Only supports galactic and later releases as that is what the [ros2 buildfarm supports for RHEL](https://ros.org/reps/rep-2000.html#galactic-geochelone-may-2021-november-2022).
+
+## ros2_debian
+
+The purpose of this repository is to provide docker images for building ros2_control on debian.
+They are automatically built and pushed to https://github.com/ros-controls/ros2_rhel/pkgs/container/ros
+
+Pull and run the images with:
+```bash
+docker pull ghcr.io/ros-controls/ros:rolling-debian
+docker run -it ghcr.io/ros-controls/ros:rolling-debian bash
+```
+
+To manually build them, you can use the following commands:
+```bash
+docker build -t ros2_debian11_humble . -f Dockerfile.debian11 --build-arg ROS_DISTRO=humble
+docker build -t ros2_debian11_iron . -f Dockerfile.debian11 --build-arg ROS_DISTRO=iron
+docker build -t ros2_debian12_jazzy . -f Dockerfile.debian12 --build-arg ROS_DISTRO=jazzy
+docker build -t ros2_debian12_rolling . -f Dockerfile.debian12 --build-arg ROS_DISTRO=rolling
+```

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -129,7 +129,7 @@ RUN \
 ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
-ADD ros-controls.$ROS_DISTRO.repos .
+COPY ros-controls.$ROS_DISTRO.repos .
 RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
   vcs import src < ros-controls.$ROS_DISTRO.repos
 # build source, ROS core
@@ -145,7 +145,7 @@ RUN colcon \
   rm -rf log src build
 
 # add default.yaml to the image
-ADD defaults.yaml /root/.colcon/defaults.yaml
+COPY defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on debian11, so install it via pip
 RUN pip3 install graphviz

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -46,6 +46,7 @@ RUN apt-get update -y -qq && \
   lsb-release \
   mlocate \
   pkg-config \
+  python3-dev \
   python3-jinja2 \
   python3-lark \
   python3-lxml \

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -148,7 +148,7 @@ RUN colcon \
 COPY defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on debian11, so install it via pip
-RUN pip3 install graphviz
+RUN pip3 install --no-cache-dir graphviz
 
 # set up sourcing of ros
 COPY ./ros_entrypoint.sh /

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -9,7 +9,7 @@ ARG NUM_THREADS=8
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update all packages
-RUN apt-get update && apt-get -y dist-upgrade \
+RUN apt-get update && apt-get -y upgrade \
   && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get -y dist-upgrade \
 # install system dependencies
 RUN apt-get update -y -qq && \
   : "system dependencies" && \
-  apt-get install -y -qq \
+  apt-get install -y -qq --no-install-recommends \
   \
   acl \
   aptitude \
@@ -118,12 +118,11 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 # install cmake 3.22.1 (the same version as Ubuntu Jammy default). Needed for RSL
+WORKDIR /usr
 RUN \
-  cd && \
-  wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
-  cd /usr && \
-  tar --strip-components=1 -xzf ~/cmake-3.22.1-linux-x86_64.tar.gz  && \
-  rm ~/cmake-3.22.1-linux-x86_64.tar.gz
+  wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
+  tar --strip-components=1 -xzf cmake-3.22.1-linux-x86_64.tar.gz  && \
+  rm cmake-3.22.1-linux-x86_64.tar.gz
 
 # ---- ROS ----
 # clone source, ROS core

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -135,15 +135,15 @@ RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/r
   vcs import src < ros-controls.$ROS_DISTRO.repos
 # build source, ROS core
 RUN colcon \
-    build \
-    --mixin release build-testing-off \
-    --cmake-args --no-warn-unused-cli \
-    --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
-      ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
-      xacro diagnostic_updater generate_parameter_library angles example_interfaces \
-      backward_ros pal_statistics \
-      ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs && \
-    rm -rf log src build
+  build \
+  --mixin release build-testing-off \
+  --cmake-args --no-warn-unused-cli \
+  --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
+  ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
+  xacro diagnostic_updater generate_parameter_library angles example_interfaces \
+  backward_ros pal_statistics \
+  ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs && \
+  rm -rf log src build
 
 # add default.yaml to the image
 ADD defaults.yaml /root/.colcon/defaults.yaml

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -155,3 +155,8 @@ RUN pip3 install graphviz
 COPY ./ros_entrypoint.sh /
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
+
+# setup github labels
+LABEL org.opencontainers.image.source=https://github.com/ros-controls/ros2_control_ci
+LABEL org.opencontainers.image.description="Debian 11 for ros-controls"
+LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -1,0 +1,157 @@
+ARG from=debian:11-slim
+
+FROM ${from}
+
+ARG CMAKE_INSTALL_PREFIX=/usr/local
+ARG NUM_THREADS=8
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update all packages
+RUN apt-get update && apt-get -y dist-upgrade \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# install system dependencies
+RUN apt-get update -y -qq && \
+  : "system dependencies" && \
+  apt-get install -y -qq \
+  \
+  acl \
+  aptitude \
+  autoconf \
+  automake \
+  build-essential \
+  cmake \
+  curl \
+  dnsutils \
+  git \
+  gnupg2 \
+  intltool \
+  libacl1-dev \
+  libasio-dev \
+  libblosc1 \
+  libbondcpp-dev \
+  libcap-dev \
+  libcgal-dev \
+  libeigen3-dev \
+  libfmt-dev \
+  liblttng-ust-dev lttng-tools python3-lttng \
+  libssl-dev \
+  libtinyxml-dev \
+  libtinyxml2-dev \
+  libxml2-utils \
+  lsb-release \
+  mlocate \
+  pkg-config \
+  python3-jinja2 \
+  python3-lark \
+  python3-lxml \
+  python3-netifaces \
+  python3-numpy \
+  python3-pip \
+  python3-psutil \
+  python3-pygraphviz \
+  python3-typeguard \
+  software-properties-common \
+  tar \
+  unzip \
+  wget \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# add the ROS 2 GPG key with apt and setup sources.list
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+  sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list' && \
+  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
+# setup environment
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ARG ROS_DISTRO
+# Environment variables defined using the ENV instruction always override an ARG instruction of the same name.
+ENV ROS_DISTRO=${ROS_DISTRO:-rolling}
+
+# ros-base include begin
+# https://github.com/osrf/docker_images/blob/master/ros/galactic/ubuntu/focal/ros-core/Dockerfile
+# https://github.com/osrf/docker_images/blob/master/ros/iron/ubuntu/jammy/ros-base/Dockerfile
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  python3-colcon-common-extensions \
+  python3-colcon-mixin \
+  python3-rosdep \
+  python3-vcstool \
+  python3-pydocstyle \
+  python3-flake8 \
+  python3-coverage \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+  https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+  colcon mixin update && \
+  colcon metadata add default \
+  https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+  colcon metadata update
+
+# install dependencies via apt
+ENV DEBCONF_NOWARNINGS=yes
+
+# install and activate ccache, lld, cppcheck
+RUN \
+  : "install ccache" \
+  && apt-get update -y -qq \
+  && apt-get -y install --no-install-recommends ccache lld cppcheck \
+  && /usr/sbin/update-ccache-symlinks \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# install cmake 3.22.1 (the same version as Ubuntu Jammy default). Needed for RSL
+RUN \
+  cd && \
+  wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
+  cd /usr && \
+  tar --strip-components=1 -xzf ~/cmake-3.22.1-linux-x86_64.tar.gz  && \
+  rm ~/cmake-3.22.1-linux-x86_64.tar.gz
+
+# ---- ROS ----
+# clone source, ROS core
+ENV ROS2_WS=/opt/ros2_ws
+RUN mkdir -p $ROS2_WS/src
+WORKDIR $ROS2_WS
+ADD ros-controls.$ROS_DISTRO.repos .
+RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
+  vcs import src < ros-controls.$ROS_DISTRO.repos
+# build source, ROS core
+RUN colcon \
+    build \
+    --mixin release build-testing-off \
+    --cmake-args --no-warn-unused-cli \
+    --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
+      ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
+      xacro diagnostic_updater generate_parameter_library angles example_interfaces \
+      backward_ros pal_statistics \
+      ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs && \
+    rm -rf log src build
+
+# add default.yaml to the image
+ADD defaults.yaml /root/.colcon/defaults.yaml
+
+# there is no python3-graphviz on debian11, so install it via pip
+RUN pip3 install graphviz
+
+# set up sourcing of ros
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT [ "/ros_entrypoint.sh" ]
+CMD ["bash"]

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -125,7 +125,7 @@ RUN \
 ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
-ADD ros-controls.$ROS_DISTRO.repos .
+COPY ros-controls.$ROS_DISTRO.repos .
 RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
   vcs import src < ros-controls.$ROS_DISTRO.repos
 # build source, ROS core
@@ -143,7 +143,7 @@ RUN \
   rm -rf log src build
 
 # add default.yaml to the image
-ADD defaults.yaml /root/.colcon/defaults.yaml
+COPY defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on debian12, so install it via pip
 RUN pip3 install --no-cache-dir graphviz --break-system-packages

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -141,8 +141,7 @@ RUN \
     backward_ros pal_statistics \
     ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
     sdformat_urdf && \
-  rm -rf log src build
-  && \
+  rm -rf log src build && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
 

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -125,9 +125,11 @@ ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .
-RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
+RUN \
+  : "build ROS core from source" \
+  vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
   vcs import src < ros-controls.$ROS_DISTRO.repos && \
-  # build source, ROS core
+  apt-get update -y -qq && \
   rosdep update --rosdistro $ROS_DISTRO && \
   rosdep install -iyr --from-path src || true && \
   colcon build \
@@ -140,6 +142,9 @@ RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/r
     ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
     sdformat_urdf && \
   rm -rf log src build
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
 
 # add default.yaml to the image
 ADD defaults.yaml /root/.colcon/defaults.yaml

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -126,7 +126,7 @@ RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .
 RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
-  vcs import src < ros-controls.$ROS_DISTRO.repos \
+  vcs import src < ros-controls.$ROS_DISTRO.repos && \
   # build source, ROS core
   rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO && \

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -126,7 +126,7 @@ RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .
 RUN \
-  : "build ROS core from source" \
+  : "build ROS core from source" && \
   vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
   vcs import src < ros-controls.$ROS_DISTRO.repos && \
   apt-get update -y -qq && \

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -126,19 +126,21 @@ RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .
 RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
-  vcs import src < ros-controls.$ROS_DISTRO.repos
-# build source, ROS core
-RUN colcon \
-    build \
-    --mixin release build-testing-off \
-    --cmake-args --no-warn-unused-cli -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized"  \
-    --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
-      ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
-      xacro diagnostic_updater generate_parameter_library angles example_interfaces \
-      backward_ros pal_statistics \
-      ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
-      sdformat_urdf && \
-    rm -rf log src build
+  vcs import src < ros-controls.$ROS_DISTRO.repos \
+  # build source, ROS core
+  rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO && \
+  rosdep install -iyr --from-path src || true && \
+  colcon build \
+  --mixin release build-testing-off \
+  --cmake-args --no-warn-unused-cli -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized"  \
+  --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
+    ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
+    xacro diagnostic_updater generate_parameter_library angles example_interfaces \
+    backward_ros pal_statistics \
+    ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
+    sdformat_urdf && \
+  rm -rf log src build
 
 # add default.yaml to the image
 ADD defaults.yaml /root/.colcon/defaults.yaml

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -23,7 +23,6 @@ RUN apt-get update -y -qq && \
   autoconf \
   automake \
   build-essential \
-  cargo \
   cmake \
   curl \
   dnsutils \
@@ -119,6 +118,12 @@ RUN \
   && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
+
+# rust, needed for zenoh
+RUN \
+  curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y && \
+  . "$HOME/.cargo/env" && \
+  rustc --version
 
 # ---- ROS ----
 # clone source, ROS core

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -8,7 +8,7 @@ ARG NUM_THREADS=8
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update all packages
-RUN apt-get update && apt-get -y dist-upgrade \
+RUN apt-get update && apt-get -y upgrade \
   && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get -y dist-upgrade \
 # install system dependencies
 RUN apt-get update -y -qq && \
   : "system dependencies" && \
-  apt-get install -y -qq \
+  apt-get install -y -qq --no-install-recommends \
   \
   acl \
   aptitude \
@@ -91,7 +91,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # colcon-devtools>0.2.3 is not released for debian12, so override it with pip
   # typing_extensions needs to be >4.7.0, but is available on apt with 4.4.0 only
   apt-get remove -y python3-colcon-devtools && \
-  pip3 install colcon-devtools typing_extensions --break-system-package && \
+  pip3 install --no-cache-dir colcon-devtools typing_extensions --break-system-package && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
 
@@ -146,7 +146,7 @@ RUN \
 ADD defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on debian12, so install it via pip
-RUN pip3 install graphviz --break-system-packages
+RUN pip3 install --no-cache-dir graphviz --break-system-packages
 
 # set up sourcing of ros
 COPY ./ros_entrypoint.sh /

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -44,6 +44,7 @@ RUN apt-get update -y -qq && \
   lsb-release \
   lttng-tools \
   mlocate \
+  nlohmann-json3-dev \
   pkg-config \
   python3-dev \
   python3-jinja2 \

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -152,3 +152,8 @@ RUN pip3 install graphviz --break-system-packages
 COPY ./ros_entrypoint.sh /
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
+
+# setup github labels
+LABEL org.opencontainers.image.source=https://github.com/ros-controls/ros2_control_ci
+LABEL org.opencontainers.image.description="Debian 12 for ros-controls"
+LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -45,6 +45,7 @@ RUN apt-get update -y -qq && \
   lttng-tools \
   mlocate \
   pkg-config \
+  python3-dev \
   python3-jinja2 \
   python3-lxml \
   python3-lark \

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -135,11 +135,11 @@ RUN \
   --mixin release build-testing-off \
   --cmake-args --no-warn-unused-cli -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized"  \
   --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
-    ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
-    xacro diagnostic_updater generate_parameter_library angles example_interfaces \
-    backward_ros pal_statistics \
-    ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
-    sdformat_urdf && \
+  ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
+  xacro diagnostic_updater generate_parameter_library angles example_interfaces \
+  backward_ros pal_statistics \
+  ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
+  sdformat_urdf && \
   rm -rf log src build
 
 # add default.yaml to the image

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -136,6 +136,7 @@ RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/r
 # build source, ROS core
 RUN \
   : "build ROS core from source" && \
+  . "$HOME/.cargo/env" && \
   colcon  build \
   --mixin release build-testing-off \
   --cmake-args --no-warn-unused-cli -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized"  \

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -1,0 +1,152 @@
+ARG from=debian:12-slim
+FROM ${from}
+
+ARG CMAKE_INSTALL_PREFIX=/usr/local
+ARG NUM_THREADS=8
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update all packages
+RUN apt-get update && apt-get -y dist-upgrade \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# install system dependencies
+RUN apt-get update -y -qq && \
+  : "system dependencies" && \
+  apt-get install -y -qq \
+  \
+  acl \
+  aptitude \
+  autoconf \
+  automake \
+  build-essential \
+  cmake \
+  curl \
+  dnsutils \
+  git \
+  gnupg2 \
+  intltool \
+  libacl1-dev \
+  libasio-dev \
+  libblosc1 \
+  libbondcpp-dev \
+  libcap-dev \
+  libcgal-dev \
+  libeigen3-dev \
+  libfmt-dev \
+  liblttng-ust-dev lttng-tools python3-lttng \
+  libssl-dev \
+  libtinyxml-dev \
+  libtinyxml2-dev \
+  lsb-release \
+  lttng-tools \
+  mlocate \
+  pkg-config \
+  python3-jinja2 \
+  python3-lxml \
+  python3-lark \
+  python3-numpy \
+  python3-pip \
+  python3-psutil \
+  python3-pygraphviz \
+  python3-typeguard \
+  software-properties-common \
+  tar \
+  unzip \
+  wget \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# add the ROS 2 GPG key with apt and setup sources.list
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+  sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list' && \
+  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
+# setup environment
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ARG ROS_DISTRO
+# Environment variables defined using the ENV instruction always override an ARG instruction of the same name.
+ENV ROS_DISTRO=${ROS_DISTRO:-iron}
+
+# ros-base include begin
+# https://github.com/osrf/docker_images/blob/master/ros/galactic/ubuntu/focal/ros-core/Dockerfile
+# https://github.com/osrf/docker_images/blob/master/ros/iron/ubuntu/jammy/ros-base/Dockerfile
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  python3-colcon-common-extensions \
+  python3-colcon-mixin \
+  python3-rosdep \
+  python3-vcstool \
+  python3-ament-pep257 \
+  python3-flake8 \
+  python3-coverage \
+  && \
+  # colcon-devtools>0.2.3 is not released for debian12, so override it with pip
+  # typing_extensions needs to be >4.7.0, but is available on apt with 4.4.0 only
+  apt-get remove -y python3-colcon-devtools && \
+  pip3 install colcon-devtools typing_extensions --break-system-package && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+  https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+  colcon mixin update && \
+  colcon metadata add default \
+  https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+  colcon metadata update
+
+# install dependencies via apt
+ENV DEBCONF_NOWARNINGS=yes
+
+# install and activate ccache, lld, cppcheck
+RUN \
+  : "install ccache" \
+  && apt-get update -y -qq \
+  && apt-get -y install --no-install-recommends ccache lld cppcheck \
+  && /usr/sbin/update-ccache-symlinks \
+  && \
+  : "remove cache" && \
+  rm -rf /var/lib/apt/lists/*
+
+# ---- ROS ----
+# clone source, ROS core
+ENV ROS2_WS=/opt/ros2_ws
+RUN mkdir -p $ROS2_WS/src
+WORKDIR $ROS2_WS
+ADD ros-controls.$ROS_DISTRO.repos .
+RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
+  vcs import src < ros-controls.$ROS_DISTRO.repos
+# build source, ROS core
+RUN colcon \
+    build \
+    --mixin release build-testing-off \
+    --cmake-args --no-warn-unused-cli -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized"  \
+    --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
+      ros2param ros2interface ros2topic ros2action ros2lifecycle ros2launch ros2run \
+      xacro diagnostic_updater generate_parameter_library angles example_interfaces \
+      backward_ros pal_statistics \
+      ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
+      sdformat_urdf && \
+    rm -rf log src build
+
+# add default.yaml to the image
+ADD defaults.yaml /root/.colcon/defaults.yaml
+
+# there is no python3-graphviz on debian12, so install it via pip
+RUN pip3 install graphviz --break-system-packages
+
+# set up sourcing of ros
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT [ "/ros_entrypoint.sh" ]
+CMD ["bash"]

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -23,6 +23,7 @@ RUN apt-get update -y -qq && \
   autoconf \
   automake \
   build-essential \
+  cargo \
   cmake \
   curl \
   dnsutils \
@@ -125,14 +126,12 @@ ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 ADD ros-controls.$ROS_DISTRO.repos .
+RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
+  vcs import src < ros-controls.$ROS_DISTRO.repos
+# build source, ROS core
 RUN \
   : "build ROS core from source" && \
-  vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
-  vcs import src < ros-controls.$ROS_DISTRO.repos && \
-  apt-get update -y -qq && \
-  rosdep update --rosdistro $ROS_DISTRO && \
-  rosdep install -iyr --from-path src || true && \
-  colcon build \
+  colcon  build \
   --mixin release build-testing-off \
   --cmake-args --no-warn-unused-cli -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized"  \
   --packages-up-to robot_state_publisher tf2_ros tf2_eigen tf2_kdl tf2_eigen_kdl yaml_cpp_vendor filters \
@@ -141,9 +140,7 @@ RUN \
     backward_ros pal_statistics \
     ackermann_msgs trajectory_msgs tf2_msgs tf2_geometry_msgs sensor_msgs geometry_msgs nav_msgs \
     sdformat_urdf && \
-  rm -rf log src build && \
-  : "remove cache" && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf log src build
 
 # add default.yaml to the image
 ADD defaults.yaml /root/.colcon/defaults.yaml

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -128,7 +128,6 @@ ADD ros-controls.$ROS_DISTRO.repos .
 RUN vcs import --input https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos src &&\
   vcs import src < ros-controls.$ROS_DISTRO.repos && \
   # build source, ROS core
-  rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO && \
   rosdep install -iyr --from-path src || true && \
   colcon build \

--- a/ros2_debian/defaults.yaml
+++ b/ros2_debian/defaults.yaml
@@ -1,0 +1,5 @@
+{
+    "build": {
+        "mixin": ["rel-with-deb-info"]
+    }
+}

--- a/ros2_debian/ros-controls.humble.repos
+++ b/ros2_debian/ros-controls.humble.repos
@@ -1,0 +1,41 @@
+repositories:
+  ros/filters:
+    type: git
+    url: https://github.com/ros2-gbp/filters-release.git
+    version: debian/humble/bullseye/filters
+  ros2-gbp/xacro:
+    type: git
+    url: https://github.com/ros2-gbp/xacro-release.git
+    version: debian/humble/bullseye/xacro
+  ros2-gbp/diagnostic_updater:
+    type: git
+    url: https://github.com/ros2-gbp/diagnostics-release.git
+    version: debian/humble/bullseye/diagnostic_updater
+  backward_ros:
+    type: git
+    url: https://github.com/ros2-gbp/backward_ros-release.git
+    version:  debian/humble/bullseye/backward_ros
+  cpp_polyfills:
+    type: git
+    url: https://github.com/PickNikRobotics/cpp_polyfills.git
+    version:  main
+  RSL:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version:  main
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version:  main
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  ackermann_msgs:
+    type: git
+    url: https://github.com/ros-drivers/ackermann_msgs.git
+    version: ros2
+  pal_statistics:
+    type: git
+    url: https://github.com/pal-robotics/pal_statistics.git
+    version: humble-devel

--- a/ros2_debian/ros-controls.jazzy.repos
+++ b/ros2_debian/ros-controls.jazzy.repos
@@ -1,0 +1,53 @@
+repositories:
+  ros/filters:
+    type: git
+    url: https://github.com/ros2-gbp/filters-release.git
+    version: debian/jazzy/bullseye/filters
+  ros2-gbp/xacro:
+    type: git
+    url: https://github.com/ros2-gbp/xacro-release.git
+    version: debian/jazzy/bullseye/xacro
+  ros2-gbp/diagnostic_updater:
+    type: git
+    url: https://github.com/ros2-gbp/diagnostics-release.git
+    version: debian/jazzy/bullseye/diagnostic_updater
+  backward_ros:
+    type: git
+    url: https://github.com/ros2-gbp/backward_ros-release.git
+    version:  debian/jazzy/bullseye/backward_ros
+  cpp_polyfills:
+    type: git
+    url: https://github.com/PickNikRobotics/cpp_polyfills.git
+    version:  main
+  rsl:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version:  main
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version:  main
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  ackermann_msgs:
+    type: git
+    url: https://github.com/ros-drivers/ackermann_msgs.git
+    version: ros2
+  sdformat_urdf:
+    type: git
+    url: https://github.com/ros/sdformat_urdf.git
+    version: jazzy
+  gazebo-release/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: jazzy
+  gazebo-release/gz_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_tools_vendor.git
+    version: jazzy
+  pal_statistics:
+    type: git
+    url: https://github.com/pal-robotics/pal_statistics.git
+    version: humble-devel

--- a/ros2_debian/ros-controls.rolling.repos
+++ b/ros2_debian/ros-controls.rolling.repos
@@ -1,0 +1,53 @@
+repositories:
+  ros/filters:
+    type: git
+    url: https://github.com/ros2-gbp/filters-release.git
+    version: debian/rolling/bullseye/filters
+  ros2-gbp/xacro:
+    type: git
+    url: https://github.com/ros2-gbp/xacro-release.git
+    version: debian/rolling/bullseye/xacro
+  ros2-gbp/diagnostic_updater:
+    type: git
+    url: https://github.com/ros2-gbp/diagnostics-release.git
+    version: debian/rolling/bullseye/diagnostic_updater
+  backward_ros:
+    type: git
+    url: https://github.com/ros2-gbp/backward_ros-release.git
+    version:  debian/rolling/bullseye/backward_ros
+  cpp_polyfills:
+    type: git
+    url: https://github.com/PickNikRobotics/cpp_polyfills.git
+    version:  main
+  rsl:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version:  main
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version:  main
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  ackermann_msgs:
+    type: git
+    url: https://github.com/ros-drivers/ackermann_msgs.git
+    version: ros2
+  sdformat_urdf:
+    type: git
+    url: https://github.com/ros/sdformat_urdf.git
+    version: rolling
+  gazebo-release/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: rolling
+  gazebo-release/gz_tools_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_tools_vendor.git
+    version: rolling
+  pal_statistics:
+    type: git
+    url: https://github.com/pal-robotics/pal_statistics.git
+    version: humble-devel

--- a/ros2_debian/ros_entrypoint.sh
+++ b/ros2_debian/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros2_ws/install/setup.bash"
+exec "$@"

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -20,8 +20,8 @@ RUN dnf install -y ros-${ROS_DISTRO}-ros-base \
 python3-rosdep \
 python3-colcon-common-extensions
 RUN rosdep init
-# somehow a wrong version of empty is installed, so we have to uninstall it first
-RUN pip3 uninstall -y empty && pip3 install vcstool colcon-mixin colcon-coveragepy-result colcon-lcov-result lark empty==3.3.4
+# somehow a wrong version of empy is installed, so we have to uninstall it first
+RUN pip3 uninstall -y empy && pip3 install vcstool colcon-mixin colcon-coveragepy-result colcon-lcov-result lark empy==3.3.4
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default \

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -12,16 +12,18 @@ RUN dnf install \
   langpacks-en \
   git \
   wget \
-  -y --refresh
-RUN dnf config-manager --set-enabled powertools
+  -y --refresh \
+  && dnf config-manager --set-enabled powertools \
+  && dnf clean all
 
 ENV ROS_DISTRO=${ROS_DISTRO}
 RUN dnf install -y ros-${ROS_DISTRO}-ros-base \
   python3-rosdep \
-  python3-colcon-common-extensions
-RUN rosdep init
+  python3-colcon-common-extensions \
+  && dnf clean all \
+  && rosdep init
 # somehow a wrong version of empy is installed, so we have to uninstall it first
-RUN pip3 uninstall -y empy && pip3 install vcstool colcon-mixin colcon-coveragepy-result colcon-lcov-result lark empy==3.3.4
+RUN pip3 uninstall -y empy && pip3 install --no-cache-dir vcstool colcon-mixin colcon-coveragepy-result colcon-lcov-result lark empy==3.3.4
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default \
@@ -50,7 +52,7 @@ RUN vcs import src < ros-controls.rhel8.repos && \
 ADD defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on rhel8, so install it via pip
-RUN pip3 install graphviz
+RUN pip3 install --no-cache-dir graphviz
 
 # set up sourcing of ros
 COPY ./ros_entrypoint.sh /

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -1,0 +1,58 @@
+FROM almalinux:8
+ARG ROS_DISTRO=rolling
+
+# install ros
+ADD http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
+RUN dnf install \
+  'dnf-command(config-manager)' \
+  epel-release \
+  cmake \
+  gcc-c++ \
+  make \
+  langpacks-en \
+  git \
+  wget \
+  -y --refresh
+RUN dnf config-manager --set-enabled powertools
+
+ENV ROS_DISTRO=${ROS_DISTRO}
+RUN dnf install -y ros-${ROS_DISTRO}-ros-base \
+python3-rosdep \
+python3-colcon-common-extensions
+RUN rosdep init
+# somehow a wrong version of empty is installed, so we have to uninstall it first
+RUN pip3 uninstall -y empty && pip3 install vcstool colcon-mixin colcon-coveragepy-result colcon-lcov-result lark empty==3.3.4
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+  https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+  colcon mixin update && \
+  colcon metadata add default \
+  https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+  colcon metadata update
+
+# build generate_parameter_library and other deps from source
+ENV ROS2_WS=/opt/ros2_ws
+RUN mkdir -p $ROS2_WS/src
+WORKDIR $ROS2_WS
+ADD ros-controls.rhel8.repos .
+RUN vcs import src < ros-controls.rhel8.repos && \
+  source /opt/ros/$ROS_DISTRO/setup.bash && \
+  rosdep update --rosdistro $ROS_DISTRO && \
+  rosdep install -iyr --from-path src && \
+  colcon build \
+    --mixin release build-testing-off \
+    --cmake-args --no-warn-unused-cli \
+    --packages-up-to generate_parameter_library pal_statistics && \
+    rm -rf log src build
+
+# add default.yaml to the image
+ADD defaults.yaml /root/.colcon/defaults.yaml
+
+# there is no python3-graphviz on rhel8, so install it via pip
+RUN pip3 install graphviz
+
+# set up sourcing of ros
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT [ "/ros_entrypoint.sh" ]
+CMD ["bash"]

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -2,7 +2,7 @@ FROM almalinux:8
 ARG ROS_DISTRO=rolling
 
 # install ros
-COPY http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
+ADD http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
 RUN dnf install \
   'dnf-command(config-manager)' \
   epel-release \
@@ -39,7 +39,7 @@ RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 COPY ros-controls.rhel8.repos .
 RUN vcs import src < ros-controls.rhel8.repos && \
-  source /opt/ros/$ROS_DISTRO/setup.bash && \
+  . /opt/ros/$ROS_DISTRO/setup.bash && \
   rosdep update --rosdistro $ROS_DISTRO && \
   rosdep install -iyr --from-path src && \
   colcon build \

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -2,7 +2,7 @@ FROM almalinux:8
 ARG ROS_DISTRO=rolling
 
 # install ros
-ADD http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
+COPY http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
 RUN dnf install \
   'dnf-command(config-manager)' \
   epel-release \
@@ -37,7 +37,7 @@ RUN colcon mixin add default \
 ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
-ADD ros-controls.rhel8.repos .
+COPY ros-controls.rhel8.repos .
 RUN vcs import src < ros-controls.rhel8.repos && \
   source /opt/ros/$ROS_DISTRO/setup.bash && \
   rosdep update --rosdistro $ROS_DISTRO && \
@@ -49,7 +49,7 @@ RUN vcs import src < ros-controls.rhel8.repos && \
   rm -rf log src build
 
 # add default.yaml to the image
-ADD defaults.yaml /root/.colcon/defaults.yaml
+COPY defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on rhel8, so install it via pip
 RUN pip3 install --no-cache-dir graphviz

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -56,3 +56,8 @@ RUN pip3 install graphviz
 COPY ./ros_entrypoint.sh /
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
+
+# setup github labels
+LABEL org.opencontainers.image.source=https://github.com/ros-controls/ros2_control_ci
+LABEL org.opencontainers.image.description="RHEL 8 for ros-controls"
+LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -17,8 +17,8 @@ RUN dnf config-manager --set-enabled powertools
 
 ENV ROS_DISTRO=${ROS_DISTRO}
 RUN dnf install -y ros-${ROS_DISTRO}-ros-base \
-python3-rosdep \
-python3-colcon-common-extensions
+  python3-rosdep \
+  python3-colcon-common-extensions
 RUN rosdep init
 # somehow a wrong version of empy is installed, so we have to uninstall it first
 RUN pip3 uninstall -y empy && pip3 install vcstool colcon-mixin colcon-coveragepy-result colcon-lcov-result lark empy==3.3.4
@@ -41,10 +41,10 @@ RUN vcs import src < ros-controls.rhel8.repos && \
   rosdep update --rosdistro $ROS_DISTRO && \
   rosdep install -iyr --from-path src && \
   colcon build \
-    --mixin release build-testing-off \
-    --cmake-args --no-warn-unused-cli \
-    --packages-up-to generate_parameter_library pal_statistics && \
-    rm -rf log src build
+  --mixin release build-testing-off \
+  --cmake-args --no-warn-unused-cli \
+  --packages-up-to generate_parameter_library pal_statistics && \
+  rm -rf log src build
 
 # add default.yaml to the image
 ADD defaults.yaml /root/.colcon/defaults.yaml

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -10,7 +10,7 @@ RUN dnf install -y langpacks-en glibc-langpack-en \
   dnf config-manager --set-enabled crb
 
 # COPY http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
-COPY http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo /etc/yum.repos.d/ros2.repo
+ADD http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo /etc/yum.repos.d/ros2.repo
 RUN dnf makecache -y
 RUN dnf install -y \
   gcc-c++ \
@@ -67,7 +67,7 @@ RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 COPY ros-controls.rhel9.repos .
 RUN vcs import src < ros-controls.rhel9.repos && \
-  source /opt/ros/$ROS_DISTRO/setup.sh && \
+  . /opt/ros/$ROS_DISTRO/setup.sh && \
   rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO && \
   rosdep install -iyr --from-path src || true && \
@@ -78,7 +78,7 @@ RUN vcs import src < ros-controls.rhel9.repos && \
   rm -rf log src build
 
 # add default.yaml to the image
-ADD defaults.yaml /root/.colcon/defaults.yaml
+COPY defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on rhel9, so install it via pip
 RUN pip3 install --no-cache-dir graphviz

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -70,10 +70,10 @@ RUN vcs import src < ros-controls.rhel9.repos && \
   rosdep update --rosdistro $ROS_DISTRO && \
   rosdep install -iyr --from-path src || true && \
   colcon build \
-    --mixin release build-testing-off \
-    --cmake-args --no-warn-unused-cli \
-    --packages-up-to generate_parameter_library pal_statistics && \
-    rm -rf log src build
+  --mixin release build-testing-off \
+  --cmake-args --no-warn-unused-cli \
+  --packages-up-to generate_parameter_library pal_statistics && \
+  rm -rf log src build
 
 # add default.yaml to the image
 ADD defaults.yaml /root/.colcon/defaults.yaml

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -9,8 +9,8 @@ RUN dnf install -y langpacks-en glibc-langpack-en \
   dnf install -y 'dnf-command(config-manager)' epel-release && \
   dnf config-manager --set-enabled crb
 
-# ADD http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
-ADD http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo /etc/yum.repos.d/ros2.repo
+# COPY http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
+COPY http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo /etc/yum.repos.d/ros2.repo
 RUN dnf makecache -y
 RUN dnf install -y \
   gcc-c++ \
@@ -65,7 +65,7 @@ RUN colcon mixin add default \
 ENV ROS2_WS=/opt/ros2_ws
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
-ADD ros-controls.rhel9.repos .
+COPY ros-controls.rhel9.repos .
 RUN vcs import src < ros-controls.rhel9.repos && \
   source /opt/ros/$ROS_DISTRO/setup.sh && \
   rosdep init && \

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -85,3 +85,8 @@ RUN pip3 install graphviz
 COPY ./ros_entrypoint.sh /
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
+
+# setup github labels
+LABEL org.opencontainers.image.source=https://github.com/ros-controls/ros2_control_ci
+LABEL org.opencontainers.image.description="RHEL 9 for ros-controls"
+LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -1,0 +1,87 @@
+FROM almalinux:9
+ARG ROS_DISTRO=rolling
+
+# ROS prerequisites
+# see https://docs.ros.org/en/rolling/Installation/RHEL-Install-RPMs.html
+RUN dnf install -y langpacks-en glibc-langpack-en
+RUN export LANG=en_US.UTF-8
+RUN dnf install -y 'dnf-command(config-manager)' epel-release
+RUN dnf config-manager --set-enabled crb
+
+# ADD http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
+ADD http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo /etc/yum.repos.d/ros2.repo
+RUN dnf makecache -y
+RUN dnf install -y \
+  gcc-c++ \
+  git \
+  make \
+  patch \
+  python3-colcon-common-extensions \
+  python3-mypy \
+  python3-pip \
+  python3-pydocstyle \
+  python3-pytest \
+  python3-pytest-repeat \
+  python3-pytest-rerunfailures \
+  python3-rosdep \
+  python3-setuptools \
+  python3-vcstool \
+  wget
+
+# install some pip packages needed for testing and
+# not available as RPMs
+# use the same versions as on Ubuntu Jammy
+RUN python3 -m pip install -U --user \
+  flake8==4.0.1 \
+  pyflakes==2.4.0 \
+  flake8-blind-except==0.1.1 \
+  flake8-class-newline \
+  flake8-deprecated \
+  colcon-mixin
+
+# install ros-base
+ENV ROS_DISTRO=${ROS_DISTRO}
+RUN dnf install -y ros-${ROS_DISTRO}-ros-base
+
+# install cmake 3.22.1 (the same version as Ubuntu Jammy default). Needed for RSL
+RUN \
+  cd && \
+  wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
+  cd /usr && \
+  tar --strip-components=1 -xzf ~/cmake-3.22.1-linux-x86_64.tar.gz  && \
+  rm ~/cmake-3.22.1-linux-x86_64.tar.gz
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+  https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+  colcon mixin update && \
+  colcon metadata add default \
+  https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+  colcon metadata update
+
+# build generate_parameter_library and other deps from source
+ENV ROS2_WS=/opt/ros2_ws
+RUN mkdir -p $ROS2_WS/src
+WORKDIR $ROS2_WS
+ADD ros-controls.rhel9.repos .
+RUN vcs import src < ros-controls.rhel9.repos && \
+  source /opt/ros/$ROS_DISTRO/setup.sh && \
+  rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO && \
+  rosdep install -iyr --from-path src || true && \
+  colcon build \
+    --mixin release build-testing-off \
+    --cmake-args --no-warn-unused-cli \
+    --packages-up-to generate_parameter_library pal_statistics && \
+    rm -rf log src build
+
+# add default.yaml to the image
+ADD defaults.yaml /root/.colcon/defaults.yaml
+
+# there is no python3-graphviz on rhel9, so install it via pip
+RUN pip3 install graphviz
+
+# set up sourcing of ros
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT [ "/ros_entrypoint.sh" ]
+CMD ["bash"]

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -3,10 +3,11 @@ ARG ROS_DISTRO=rolling
 
 # ROS prerequisites
 # see https://docs.ros.org/en/rolling/Installation/RHEL-Install-RPMs.html
-RUN dnf install -y langpacks-en glibc-langpack-en
-RUN export LANG=en_US.UTF-8
-RUN dnf install -y 'dnf-command(config-manager)' epel-release
-RUN dnf config-manager --set-enabled crb
+RUN dnf install -y langpacks-en glibc-langpack-en \
+  && dnf clean all && \
+  export LANG=en_US.UTF-8 && \
+  dnf install -y 'dnf-command(config-manager)' epel-release && \
+  dnf config-manager --set-enabled crb
 
 # ADD http://packages.ros.org/ros2/rhel/ros2.repo /etc/yum.repos.d/ros2.repo
 ADD http://packages.ros.org/ros2-testing/rhel/ros2-testing.repo /etc/yum.repos.d/ros2.repo
@@ -26,12 +27,13 @@ RUN dnf install -y \
   python3-rosdep \
   python3-setuptools \
   python3-vcstool \
-  wget
+  wget \
+  && dnf clean all
 
 # install some pip packages needed for testing and
 # not available as RPMs
 # use the same versions as on Ubuntu Jammy
-RUN python3 -m pip install -U --user \
+RUN python3 -m pip install --no-cache-dir -U --user \
   flake8==4.0.1 \
   pyflakes==2.4.0 \
   flake8-blind-except==0.1.1 \
@@ -41,15 +43,15 @@ RUN python3 -m pip install -U --user \
 
 # install ros-base
 ENV ROS_DISTRO=${ROS_DISTRO}
-RUN dnf install -y ros-${ROS_DISTRO}-ros-base
+RUN dnf install -y ros-${ROS_DISTRO}-ros-base \
+  && dnf clean all
 
 # install cmake 3.22.1 (the same version as Ubuntu Jammy default). Needed for RSL
+WORKDIR /usr
 RUN \
-  cd && \
-  wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
-  cd /usr && \
-  tar --strip-components=1 -xzf ~/cmake-3.22.1-linux-x86_64.tar.gz  && \
-  rm ~/cmake-3.22.1-linux-x86_64.tar.gz
+  wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
+  tar --strip-components=1 -xzf cmake-3.22.1-linux-x86_64.tar.gz  && \
+  rm cmake-3.22.1-linux-x86_64.tar.gz
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default \
@@ -79,7 +81,7 @@ RUN vcs import src < ros-controls.rhel9.repos && \
 ADD defaults.yaml /root/.colcon/defaults.yaml
 
 # there is no python3-graphviz on rhel9, so install it via pip
-RUN pip3 install graphviz
+RUN pip3 install --no-cache-dir graphviz
 
 # set up sourcing of ros
 COPY ./ros_entrypoint.sh /

--- a/ros2_rhel/defaults.yaml
+++ b/ros2_rhel/defaults.yaml
@@ -1,0 +1,5 @@
+{
+    "build": {
+        "mixin": ["rel-with-deb-info"]
+    }
+}

--- a/ros2_rhel/ros-controls.rhel8.repos
+++ b/ros2_rhel/ros-controls.rhel8.repos
@@ -1,0 +1,17 @@
+repositories:
+  rsl:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version:  main
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version:  main
+  cpp_polyfills:
+    type: git
+    url: https://github.com/PickNikRobotics/cpp_polyfills.git
+    version:  main
+  pal_statistics:
+    type: git
+    url: https://github.com/pal-robotics/pal_statistics.git
+    version: humble-devel

--- a/ros2_rhel/ros-controls.rhel9.repos
+++ b/ros2_rhel/ros-controls.rhel9.repos
@@ -1,0 +1,13 @@
+repositories:
+  rsl:
+    type: git
+    url: https://github.com/christophfroehlich/RSL.git
+    version:  main
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version:  main
+  pal_statistics:
+    type: git
+    url: https://github.com/pal-robotics/pal_statistics.git
+    version: humble-devel

--- a/ros2_rhel/ros_entrypoint.sh
+++ b/ros2_rhel/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"


### PR DESCRIPTION
Github actions are automatically deactivated if the repository doesn't have any changes for 60 days. 
I propose to move all the docker images from the ros2_debian and ros2_rhel repo here, so we will hit this timeout very unlikely.

Additionally, I cleaned up the docker files and made zenoh compiling on debian12.