### PR TITLE
Add our own Ubuntu docker images

### DIFF
--- a/.github/workflows/build_and_publish_ubuntu_docker.yaml
+++ b/.github/workflows/build_and_publish_ubuntu_docker.yaml
@@ -22,10 +22,22 @@ jobs:
         include:
           - ros_distro: 'humble'
             base_image: 'ubuntu:jammy'
+            ros-repo-packages: ""
           - ros_distro: 'jazzy'
             base_image: 'ubuntu:noble'
+            ros-repo-packages: ""
           - ros_distro: 'rolling'
             base_image: 'ubuntu:noble'
+            ros-repo-packages: ""
+          - ros_distro: 'humble'
+            base_image: 'ubuntu:jammy'
+            ros-repo-packages: "-testing"
+          - ros_distro: 'jazzy'
+            base_image: 'ubuntu:noble'
+            ros-repo-packages: "-testing"
+          - ros_distro: 'rolling'
+            base_image: 'ubuntu:noble'
+            ros-repo-packages: "-testing"
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -39,7 +51,8 @@ jobs:
           context: ros2_ubuntu
           push: false
           file: ros2_ubuntu/Dockerfile
-          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-ubuntu
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-ubuntu${{ matrix.ros-repo-packages }}
           build-args: |
             FROM=${{ matrix.base_image }}
             ROS_DISTRO=${{ matrix.ros_distro }}
+            ROS_REPO_PACKAGES=${{ matrix.ros-repo-packages }}

--- a/.github/workflows/build_and_publish_ubuntu_docker.yaml
+++ b/.github/workflows/build_and_publish_ubuntu_docker.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: ros2_ubuntu
-          push: false
+          push: true
           file: ros2_ubuntu/Dockerfile
           tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-ubuntu${{ matrix.ros-repo-packages }}
           build-args: |

--- a/.github/workflows/build_and_publish_ubuntu_docker.yaml
+++ b/.github/workflows/build_and_publish_ubuntu_docker.yaml
@@ -1,0 +1,45 @@
+---
+name: Build and publish Ubuntu docker images
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/build_and_publish_ubuntu_docker.yaml'
+      - 'ros2_ubuntu/**'
+  schedule:
+    - cron: '1 2 * * MON'
+
+jobs:
+  build_images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ros_distro: 'humble'
+            base_image: 'ubuntu:jammy'
+          - ros_distro: 'jazzy'
+            base_image: 'ubuntu:noble'
+          - ros_distro: 'rolling'
+            base_image: 'ubuntu:noble'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ros2_ubuntu
+          push: false
+          file: ros2_ubuntu/Dockerfile
+          tags: ghcr.io/${{ github.repository_owner }}/ros:${{ matrix.ros_distro }}-ubuntu
+          build-args: |
+            FROM=${{ matrix.base_image }}
+            ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/reusable-abi-check.yml
+++ b/.github/workflows/reusable-abi-check.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ros-industrial/industrial_ci@master
         env:
-          DOCKER_IMAGE: ghcr.io/sloretz/ros:${{ inputs.ros_distro }}-ros-base
+          DOCKER_IMAGE: ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-ubuntu-testing
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: testing
           ABICHECK_URL: github:${{ github.repository }}#${{ github.base_ref }}

--- a/.github/workflows/reusable-build-coverage.yml
+++ b/.github/workflows/reusable-build-coverage.yml
@@ -15,7 +15,7 @@ jobs:
   coverage:
     name: coverage build ${{ inputs.ros_distro }}
     runs-on: ubuntu-latest
-    container: ghcr.io/sloretz/ros:${{ inputs.ros_distro }}-ros-base
+    container: ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-ubuntu-testing
     defaults:
       run:
         shell: bash

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -104,6 +104,14 @@ jobs:
           restore-keys: |
             ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ccache-${{ env.CACHE_PREFIX }}
+      - name: Get docker image name
+        id: docker_image
+        run: |
+          if [ "${{ inputs.ros_repo }}" = "main" ]; then
+            echo "DOCKER_IMAGE=ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-ubuntu" >> $GITHUB_OUTPUT
+          else
+            echo "DOCKER_IMAGE=ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-ubuntu-testing" >> $GITHUB_OUTPUT
+          fi
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
@@ -111,8 +119,8 @@ jobs:
           NOT_TEST_BUILD: ${{ inputs.not_test_build }}
           DOWNSTREAM_WORKSPACE: ${{ inputs.downstream_workspace }}
           NOT_TEST_DOWNSTREAM: ${{ inputs.not_test_downstream }}
-          DOCKER_IMAGE: ghcr.io/sloretz/ros:${{ inputs.ros_distro }}-ros-base
-          ROS_REPO: ${{ inputs.ros_repo }}
+          DOCKER_IMAGE: ${{ env.DOCKER_IMAGE }}
+          ROS_REPO: ${{ steps.docker_image.outputs.DOCKER_IMAGE }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}
           ROSDEP_SKIP_KEYS: ${{ inputs.rosdep_skip_keys }}
           ADDITIONAL_DEBS: ${{ inputs.additional_debs }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -119,8 +119,8 @@ jobs:
           NOT_TEST_BUILD: ${{ inputs.not_test_build }}
           DOWNSTREAM_WORKSPACE: ${{ inputs.downstream_workspace }}
           NOT_TEST_DOWNSTREAM: ${{ inputs.not_test_downstream }}
-          DOCKER_IMAGE: ${{ env.DOCKER_IMAGE }}
-          ROS_REPO: ${{ steps.docker_image.outputs.DOCKER_IMAGE }}
+          DOCKER_IMAGE: ${{ steps.docker_image.outputs.DOCKER_IMAGE }}
+          ROS_REPO: ${{ inputs.ros_repo }}
           OS_CODE_NAME: ${{ inputs.os_code_name }}
           ROSDEP_SKIP_KEYS: ${{ inputs.rosdep_skip_keys }}
           ADDITIONAL_DEBS: ${{ inputs.additional_debs }}

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/rolling-binary-build.yml'
-      - './.github/workflows/reusable-industrial-ci-with-cache.yml'
+      - '.github/workflows/reusable-industrial-ci-with-cache.yml'
       - 'ros_controls.rolling.repos'
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This repository holds reusable workflows for CI of the ros2_control framework as well as docker images for building the ros2_control stack on different platforms, supporting all current releases as by [REP-2000](https://ros.org/reps/rep-2000.html).
+They are automatically built and pushed to the [GitHub Container Registry (ghcr.io)](https://github.com/orgs/ros-controls/packages/container/package/ros) and can be used as base images for building the ros2_control stack.
 
-It also builds the full ros2_control stack once per day.
+Within this repo the full ros2_control stack is built and tested once per day.
 
 ## Released versions
 
@@ -27,9 +28,7 @@ This is a sample Dockerfile that show ros2 installed on almalinux based on the [
 The image tries to emulate the official ros2 images but on alma (downstream RHEL) linux. Therefore a few extra packages can be found within this repo that are not mentioned at the above link, i.e. colcon, etc.
 
 ## ros2_debian
-
-The purpose of this repository is to provide docker images for building ros2_control on debian.
-They are automatically built and pushed to https://github.com/ros-controls/ros2_rhel/pkgs/container/ros
+Provides docker images for building ros2_control on debian.
 
 Pull and run the images with:
 ```bash
@@ -40,7 +39,6 @@ docker run -it ghcr.io/ros-controls/ros:rolling-debian bash
 To manually build them, you can use the following commands:
 ```bash
 docker build -t ros2_debian11_humble . -f Dockerfile.debian11 --build-arg ROS_DISTRO=humble
-docker build -t ros2_debian11_iron . -f Dockerfile.debian11 --build-arg ROS_DISTRO=iron
 docker build -t ros2_debian12_jazzy . -f Dockerfile.debian12 --build-arg ROS_DISTRO=jazzy
 docker build -t ros2_debian12_rolling . -f Dockerfile.debian12 --build-arg ROS_DISTRO=rolling
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This repository holds reusable workflows for CI of the ros2_control framework as well as docker images for building the ros2_control stack on different platforms, supporting all current releases as by [REP-2000](https://ros.org/reps/rep-2000.html).
+This repository holds reusable workflows for CI of the ros2_control framework as well as weekly updated docker images for building the ros2_control stack on different platforms, supporting all current releases as by [REP-2000](https://ros.org/reps/rep-2000.html).
 They are automatically built and pushed to the [GitHub Container Registry (ghcr.io)](https://github.com/orgs/ros-controls/packages/container/package/ros) and can be used as base images for building the ros2_control stack.
 
 Within this repo the full ros2_control stack is built and tested once per day.
@@ -21,6 +21,9 @@ We thrive to make the rolling development version of the ros2_control stack comp
 [![Check Rolling Compatibility on Jazzy with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-jazzy-binary-build.yml)
 
 [![Check Rolling Compatibility on Humble with Stack Build](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml/badge.svg)](https://github.com/ros-controls/ros2_control_ci/actions/workflows/rolling-compatibility-humble-binary-build.yml)
+
+## ros2_ubuntu
+Extension of the [official OSRF docker images](https://github.com/osrf/docker_images), but with versions for `ros2`(main) and `ros2-testing` binaries.
 
 ## ros2_rhel
 This is a sample Dockerfile that show ros2 installed on almalinux based on the [binary installation instructions at docs.ros.org](https://docs.ros.org/en/rolling/Installation/RHEL-Install-RPMs.html). The most recent public build can be found with the docker tag: `ghcr.io/ros-controls/ros:<ROS_DISTRO>-rhel` where `<ROS_DISTRO>` is replaced with the ros distribution you are targeting.

--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+ARG FROM=ubuntu:noble
+FROM ${FROM}
+
+ARG ROS_DISTRO=rolling
+
+# Setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install packages
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup keys
+RUN set -eux; \
+       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /usr/share/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros2-latest-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
+
+# Setup sources.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+# Setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO ${ROS_DISTRO}
+
+# Install ROS packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-${ROS_DISTRO}-ros-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -17,6 +17,7 @@ ARG FROM=ubuntu:noble
 FROM ${FROM}
 
 ARG ROS_DISTRO=rolling
+ARG ROS_REPO_PACKAGES=""
 
 # Setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
@@ -43,7 +44,7 @@ RUN set -eux; \
        rm -rf "$GNUPGHOME"
 
 # Setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2${ROS_REPO_PACKAGES}/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
 # Setup environment
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8

--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -53,7 +53,7 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 
 # Install ROS packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-${ROS_DISTRO}-ros-core \
+    ros-${ROS_DISTRO}-ros-base \
     && rm -rf /var/lib/apt/lists/*
 
 # Setup entrypoint

--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
        rm -rf "$GNUPGHOME"
 
 # Setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2${ROS_REPO_PACKAGES}/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2${ROS_REPO_PACKAGES}/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list
 # Setup environment
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8

--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -45,10 +45,10 @@ RUN set -eux; \
 # Setup sources.list
 RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg ] http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
 # Setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
-ENV ROS_DISTRO ${ROS_DISTRO}
+ENV ROS_DISTRO=${ROS_DISTRO}
 
 # Install ROS packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -60,3 +60,8 @@ COPY ./ros_entrypoint.sh /
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
+
+# setup github labels
+LABEL org.opencontainers.image.source=https://github.com/ros-controls/ros2_control_ci
+LABEL org.opencontainers.image.description="${FROM}/${ROS_DISTRO} for ros-controls"
+LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/ros2_ubuntu/ros_entrypoint.sh
+++ b/ros2_ubuntu/ros_entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Setup ROS environment
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+exec "$@"


### PR DESCRIPTION
As we recently had problems with the docker images in the workflows using main binaries (ABI break of fastcdr, see https://github.com/eProsima/Fast-CDR/issues/266), I want to use images with ros2-testing binaries. But there are none out there for all current distro, so let's create our own.

Tested with realtime_tools, and it works great!
https://github.com/ros-controls/realtime_tools/pull/313