### PR TITLE
Auto-generate dependencies for source build

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -90,6 +90,7 @@ jobs:
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
             ${{ steps.check_local_repos.outputs.repo_file }}
+            https://raw.githubusercontent.com/ros-controls/ros2_control_ci/refs/heads/fix/source/ros_controls_source.${{ inputs.ros2_repo_branch }}.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon-defaults: |
             {

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -82,6 +82,11 @@ jobs:
             echo "repo_file=" >> $GITHUB_OUTPUT
           fi
 
+      # Run the generator and output the results to a file.
+      - run: |
+          rosinstall_generator ${{ steps.package_list_action.outputs.package_list }} --rosdistro ${{ inputs.ros_distro }} \
+          --deps-only --deps --upstream-development > /tmp/deps.repos
+
       - uses: ros-tooling/action-ros-ci@0.4.1
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}
@@ -89,9 +94,8 @@ jobs:
           package-name: ${{ steps.package_list_action.outputs.package_list }}
           rosdep-skip-keys: rti-connext-dds-7.3.0
           vcs-repo-file-url: |
-            https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
             ${{ steps.check_local_repos.outputs.repo_file }}
-            https://raw.githubusercontent.com/ros-controls/ros2_control_ci/refs/heads/fix/source/ros_controls_source.${{ inputs.ros_distro }}.repos
+            /tmp/deps.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon-defaults: |
             {

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -66,24 +66,16 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           path: ${{ env.repo_path }}
-      - id: package_list_action
+
+      - name: Get a list of all packages
+        id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
         with:
           path: ${{ env.repo_path }}
 
-      - name: Check for local repos file
-        id: check_local_repos
-        run: |
-          if [ -f  ${{ env.repo_path }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos ]; then
-            echo "Local repos file found"
-            echo "repo_file=${{ env.repo_path }}/${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos" >> $GITHUB_OUTPUT
-          else
-            echo "No local repos file found"
-            echo "repo_file=" >> $GITHUB_OUTPUT
-          fi
-
       # Run the generator and output the results to a file.
-      - run: |
+      - name: Use rosinstall_generator to get all dependencies
+        run: |
           rosinstall_generator ${{ steps.package_list_action.outputs.package_list }} --rosdistro ${{ inputs.ros_distro }} \
           --deps-only --deps --upstream-development > /tmp/deps.repos
 
@@ -94,7 +86,6 @@ jobs:
           package-name: ${{ steps.package_list_action.outputs.package_list }}
           rosdep-skip-keys: rti-connext-dds-7.3.0
           vcs-repo-file-url: |
-            ${{ steps.check_local_repos.outputs.repo_file }}
             /tmp/deps.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon-defaults: |

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -87,7 +87,7 @@ jobs:
           target-ros2-distro: ${{ inputs.ros_distro }}
           ref: ${{ inputs.ref }}
           package-name: ${{ steps.package_list_action.outputs.package_list }}
-          rosdep-skip-keys: rti-connext-dds-7.3.0-ros
+          rosdep-skip-keys: rti-connext-dds-7.3.0
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
             ${{ steps.check_local_repos.outputs.repo_file }}

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -87,10 +87,11 @@ jobs:
           target-ros2-distro: ${{ inputs.ros_distro }}
           ref: ${{ inputs.ref }}
           package-name: ${{ steps.package_list_action.outputs.package_list }}
+          rosdep-skip-keys: rti-connext-dds-7.3.0-ros
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
             ${{ steps.check_local_repos.outputs.repo_file }}
-            https://raw.githubusercontent.com/ros-controls/ros2_control_ci/refs/heads/fix/source/ros_controls_source.${{ inputs.ros2_repo_branch }}.repos
+            https://raw.githubusercontent.com/ros-controls/ros2_control_ci/refs/heads/fix/source/ros_controls_source.${{ inputs.ros_distro }}.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon-defaults: |
             {

--- a/ros_controls_source.rolling.repos
+++ b/ros_controls_source.rolling.repos
@@ -1,0 +1,45 @@
+repositories:
+  diagnostic_updater:
+    type: git
+    url: https://github.com/ros/diagnostics.git
+    version: ros2
+  backward_ros:
+    type: git
+    url: https://github.com/pal-robotics/backward_ros.git
+    version: foxy-devel
+  generate_parameter_library:
+    type: git
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version:  main
+  pal_statistics:
+    type: git
+    url: https://github.com/pal-robotics/pal_statistics.git
+    version: humble-devel
+  ros_workspace:
+    type: git
+    url: https://github.com/ros2/ros_workspace.git
+    version: latest
+  sdformat_urdf:
+    type: git
+    url: https://github.com/ros2/sdformat_urdf.git
+    version: rolling
+  cpp_polyfills:
+    type: git
+    url: https://github.com/PickNikRobotics/cpp_polyfills.git
+    version:  main
+  rsl:
+    type: git
+    url: https://github.com/PickNikRobotics/RSL.git
+    version:  main
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  ackermann_msgs:
+    type: git
+    url: https://github.com/ros-drivers/ackermann_msgs.git
+    version: ros2
+  filters:
+    type: git
+    url: https://github.com/ros/filters.git
+    version: ros2

--- a/ros_controls_source.rolling.repos
+++ b/ros_controls_source.rolling.repos
@@ -21,7 +21,11 @@ repositories:
     version: latest
   sdformat_urdf:
     type: git
-    url: https://github.com/ros/sdformat_urdf.git
+    url: https://github.com/gazebo-release/sdformat_urdf.git
+    version: rolling
+  sdformat_vendor:
+    type: git
+    url: https://github.com/ros/sdformat_vendor.git
     version: rolling
   cpp_polyfills:
     type: git

--- a/ros_controls_source.rolling.repos
+++ b/ros_controls_source.rolling.repos
@@ -21,7 +21,7 @@ repositories:
     version: latest
   sdformat_urdf:
     type: git
-    url: https://github.com/ros2/sdformat_urdf.git
+    url: https://github.com/ros/sdformat_urdf.git
     version: rolling
   cpp_polyfills:
     type: git


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control/issues/2161 by using the [rosinstall_generato](https://github.com/ros-tooling/action-ros-ci/tree/0.4.1/?tab=readme-ov-file#build-with-a-custom-repos-or-rosinstall-file)r for creating all dependencies. (no need for ros2.repos any more).
Successfully tested with https://github.com/ros-controls/ros2_control/actions/runs/14400388586/job/40399334766

I also added the connext-dds to the rosdep-skip-keys, which fixes https://github.com/ros-controls/kinematics_interface/issues/130 and fixes https://github.com/ros-controls/realtime_tools/issues/312 and fixes https://github.com/ros-controls/ros2_control/issues/2170 and fixes https://github.com/ros-controls/ros2_controllers/issues/1633