### PR TITLE
Bootstrap rosdep

### DIFF
--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -59,6 +59,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     $(if [ $(lsb_release -sc) = "jammy" ]; then echo "libssl-dev python3-dev clang lcov python3-rosinstall-generator python3-flake8-docstrings python3-pip python3-pytest-cov python3-flake8-blind-except python3-flake8-builtins python3-flake8-class-newline python3-flake8-comprehensions python3-flake8-deprecated python3-flake8-import-order python3-flake8-quotes python3-pytest-repeat python3-pytest-rerunfailures ros-dev-tools python3-colcon-coveragepy-result python3-colcon-lcov-result python3-colcon-meson python3-colcon-mixin libasio-dev libtinyxml2-dev"; fi) \
     && rm -rf /var/lib/apt/lists/*
 
+# Bootstrap rosdep
+RUN rosdep init && \
+    rosdep update --rosdistro $ROS_DISTRO
+
 # Setup entrypoint
 COPY ./ros_entrypoint.sh /
 


### PR DESCRIPTION
Since #300 the setup-ros setup is not executed any more with the coverage build, and the rosdep step is failing now.

Fixing this by bootstrapping rosdep already in the docker image.