### PR TITLE
rosinstall_generator fails regularily: retry for 5min

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -73,11 +73,13 @@ jobs:
         with:
           path: ${{ env.repo_path }}
 
-      # Run the generator and output the results to a file.
+      # Run the generator and output the results to a file with retry logic.
       - name: Use rosinstall_generator to get all dependencies
         run: |
-          rosinstall_generator ${{ steps.package_list_action.outputs.package_list }} --rosdistro ${{ inputs.ros_distro }} \
-          --deps-only --deps --upstream-development > /tmp/deps.repos
+          for i in {1..5}; do
+            rosinstall_generator ${{ steps.package_list_action.outputs.package_list }} --rosdistro ${{ inputs.ros_distro }} \
+            --deps-only --deps --upstream-development > /tmp/deps.repos && break || echo "retry #${i} .." && sleep 60;
+          done
 
       - uses: ros-tooling/action-ros-ci@0.4.1
         with:


### PR DESCRIPTION
The new source build fails often because of 403 or 404 HTTP error (don't ask me if this is normal)

`urllib.error.HTTPError: HTTP Error 403: Forbidden (http://repo.ros2.org/rosdistro_cache/jazzy-cache.yaml.gz)`

We could simply retry it for a couple of minutes