### PR TITLE
Add install dependencies step for debian jobs

### DIFF
--- a/.github/workflows/reusable-debian-build.yml
+++ b/.github/workflows/reusable-debian-build.yml
@@ -61,6 +61,12 @@ jobs:
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list@master
         with:
           path: ${{ env.path }}
+      - name: Install dependencies
+        shell: bash
+        run: |
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          rosdep update --rosdistro ${{ inputs.ros_distro }}
+          rosdep install -iyr --from-path src || true # ignore errors, as some packages might not be available
       - name: Build workspace
         shell: bash
         run: |

--- a/.github/workflows/reusable-debian-build.yml
+++ b/.github/workflows/reusable-debian-build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
           rosdep update --rosdistro ${{ inputs.ros_distro }}
           rosdep install -iyr --from-path src || true # ignore errors, as some packages might not be available
       - name: Build workspace

--- a/.github/workflows/reusable-debian-build.yml
+++ b/.github/workflows/reusable-debian-build.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          apt-get update
           source /opt/ros2_ws/install/setup.bash
           rosdep update --rosdistro ${{ inputs.ros_distro }}
           rosdep install -iyr --from-path src || true # ignore errors, as some packages might not be available


### PR DESCRIPTION
This is to allow the debian jobs to install the dependencies before building and executing tests

Needed for https://github.com/ros-controls/ros2_control/pull/2202