### PR TITLE
Use bookworm releases instead of bullseye

### DIFF
--- a/ros2_debian/ros-controls.jazzy.repos
+++ b/ros2_debian/ros-controls.jazzy.repos
@@ -2,19 +2,19 @@ repositories:
   ros/filters:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
-    version: debian/jazzy/bullseye/filters
+    version: debian/jazzy/bookworm/filters
   ros2-gbp/xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
-    version: debian/jazzy/bullseye/xacro
+    version: debian/jazzy/bookworm/xacro
   ros2-gbp/diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
-    version: debian/jazzy/bullseye/diagnostic_updater
+    version: debian/jazzy/bookworm/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/jazzy/bullseye/backward_ros
+    version:  debian/jazzy/bookworm/backward_ros
   cpp_polyfills:
     type: git
     url: https://github.com/PickNikRobotics/cpp_polyfills.git

--- a/ros2_debian/ros-controls.kilted.repos
+++ b/ros2_debian/ros-controls.kilted.repos
@@ -2,19 +2,19 @@ repositories:
   ros/filters:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
-    version: debian/rolling/bullseye/filters
+    version: debian/rolling/bookworm/filters
   ros2-gbp/xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
-    version: debian/rolling/bullseye/xacro
+    version: debian/rolling/bookworm/xacro
   ros2-gbp/diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
-    version: debian/rolling/bullseye/diagnostic_updater
+    version: debian/rolling/bookworm/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/rolling/bullseye/backward_ros
+    version:  debian/rolling/bookworm/backward_ros
   cpp_polyfills:
     type: git
     url: https://github.com/PickNikRobotics/cpp_polyfills.git

--- a/ros2_debian/ros-controls.rolling.repos
+++ b/ros2_debian/ros-controls.rolling.repos
@@ -2,19 +2,19 @@ repositories:
   ros/filters:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
-    version: debian/rolling/bullseye/filters
+    version: debian/rolling/bookworm/filters
   ros2-gbp/xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
-    version: debian/rolling/bullseye/xacro
+    version: debian/rolling/bookworm/xacro
   ros2-gbp/diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
-    version: debian/rolling/bullseye/diagnostic_updater
+    version: debian/rolling/bookworm/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/rolling/bullseye/backward_ros
+    version:  debian/rolling/bookworm/backward_ros
   cpp_polyfills:
     type: git
     url: https://github.com/PickNikRobotics/cpp_polyfills.git


### PR DESCRIPTION
See the failing jobs on https://github.com/ros-controls/control_toolbox/pull/364

is it good practice to use the release repos (would be more equivalent to ubuntu binary builds), or should we use the development branches (would be more equivalent to source builds) instead? Currently, we have a mixture.