### PR TITLE
Debian: Use release packages instead of development version

### DIFF
--- a/ros2_debian/ros-controls.humble.repos
+++ b/ros2_debian/ros-controls.humble.repos
@@ -35,6 +35,10 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/generate_parameter_library-release.git
     version: debian/humble/bullseye/generate_parameter_library
+  generate_parameter_library/parameter_traits:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/humble/bullseye/parameter_traits
   angles:
     type: git
     url: https://github.com/ros2-gbp/angles-release.git

--- a/ros2_debian/ros-controls.humble.repos
+++ b/ros2_debian/ros-controls.humble.repos
@@ -3,39 +3,51 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
     version: debian/humble/bullseye/filters
-  ros2-gbp/xacro:
+  xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
     version: debian/humble/bullseye/xacro
-  ros2-gbp/diagnostic_updater:
+  diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
     version: debian/humble/bullseye/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/humble/bullseye/backward_ros
-  cpp_polyfills:
+    version: debian/humble/bullseye/backward_ros
+  cpp_polyfills/tcb_span:
     type: git
-    url: https://github.com/PickNikRobotics/cpp_polyfills.git
-    version:  main
-  RSL:
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/humble/bullseye/tcb_span
+  cpp_polyfills/tl_expected:
     type: git
-    url: https://github.com/PickNikRobotics/RSL.git
-    version:  main
-  generate_parameter_library:
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/humble/bullseye/tl_expected
+  rsl:
     type: git
-    url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version:  main
+    url: https://github.com/ros2-gbp/RSL-release.git
+    version: debian/humble/bullseye/rsl
+  generate_parameter_library/generate_parameter_library_py:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/humble/bullseye/generate_parameter_library_py
+  generate_parameter_library/generate_parameter_library:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/humble/bullseye/generate_parameter_library
   angles:
     type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
+    url: https://github.com/ros2-gbp/angles-release.git
+    version: debian/humble/bullseye/angles
   ackermann_msgs:
     type: git
-    url: https://github.com/ros-drivers/ackermann_msgs.git
-    version: ros2
-  pal_statistics:
+    url: https://github.com/ros2-gbp/ackermann_msgs-release.git
+    version: debian/humble/bullseye/ackermann_msgs
+  pal_statistics/pal_statistics:
     type: git
-    url: https://github.com/pal-robotics/pal_statistics.git
-    version: humble-devel
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/humble/bullseye/pal_statistics
+  pal_statistics/pal_statistics_msgs:
+    type: git
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/humble/bullseye/pal_statistics_msgs

--- a/ros2_debian/ros-controls.humble.repos
+++ b/ros2_debian/ros-controls.humble.repos
@@ -27,18 +27,23 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/RSL-release.git
     version: debian/humble/bullseye/rsl
-  generate_parameter_library/generate_parameter_library_py:
+  generate_parameter_library:
     type: git
-    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-    version: debian/humble/bullseye/generate_parameter_library_py
-  generate_parameter_library/generate_parameter_library:
-    type: git
-    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-    version: debian/humble/bullseye/generate_parameter_library
-  generate_parameter_library/parameter_traits:
-    type: git
-    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-    version: debian/humble/bullseye/parameter_traits
+    url: https://github.com/PickNikRobotics/generate_parameter_library.git
+    version: main
+  # TODO: switch to released version once https://github.com/PickNikRobotics/generate_parameter_library/issues/262 is fixed
+  # generate_parameter_library/generate_parameter_library_py:
+  #   type: git
+  #   url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+  #   version: debian/humble/bullseye/generate_parameter_library_py
+  # generate_parameter_library/generate_parameter_library:
+  #   type: git
+  #   url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+  #   version: debian/humble/bullseye/generate_parameter_library
+  # generate_parameter_library/parameter_traits:
+  #   type: git
+  #   url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+  #   version: debian/humble/bullseye/parameter_traits
   angles:
     type: git
     url: https://github.com/ros2-gbp/angles-release.git

--- a/ros2_debian/ros-controls.jazzy.repos
+++ b/ros2_debian/ros-controls.jazzy.repos
@@ -3,51 +3,63 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
     version: debian/jazzy/bookworm/filters
-  ros2-gbp/xacro:
+  xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
     version: debian/jazzy/bookworm/xacro
-  ros2-gbp/diagnostic_updater:
+  diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
     version: debian/jazzy/bookworm/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/jazzy/bookworm/backward_ros
-  cpp_polyfills:
+    version: debian/jazzy/bookworm/backward_ros
+  cpp_polyfills/tcb_span:
     type: git
-    url: https://github.com/PickNikRobotics/cpp_polyfills.git
-    version:  main
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/jazzy/bookworm/tcb_span
+  cpp_polyfills/tl_expected:
+    type: git
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/jazzy/bookworm/tl_expected
   rsl:
     type: git
-    url: https://github.com/PickNikRobotics/RSL.git
-    version:  main
-  generate_parameter_library:
+    url: https://github.com/ros2-gbp/RSL-release.git
+    version: debian/jazzy/bookworm/rsl
+  generate_parameter_library/generate_parameter_library_py:
     type: git
-    url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version:  main
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/jazzy/bookworm/generate_parameter_library_py
+  generate_parameter_library/generate_parameter_library:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/jazzy/bookworm/generate_parameter_library
   angles:
     type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
+    url: https://github.com/ros2-gbp/angles-release.git
+    version: debian/jazzy/bookworm/angles
   ackermann_msgs:
     type: git
-    url: https://github.com/ros-drivers/ackermann_msgs.git
-    version: ros2
+    url: https://github.com/ros2-gbp/ackermann_msgs-release.git
+    version: debian/jazzy/bookworm/ackermann_msgs
   sdformat_urdf:
     type: git
-    url: https://github.com/ros/sdformat_urdf.git
-    version: jazzy
-  gazebo-release/sdformat_vendor:
+    url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+    version: debian/jazzy/bookworm/sdformat_urdf
+  sdformat_vendor:
     type: git
     url: https://github.com/gazebo-release/sdformat_vendor.git
     version: jazzy
-  gazebo-release/gz_tools_vendor:
+  gz_tools_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_tools_vendor.git
     version: jazzy
-  pal_statistics:
+  pal_statistics/pal_statistics:
     type: git
-    url: https://github.com/pal-robotics/pal_statistics.git
-    version: humble-devel
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/jazzy/bookworm/pal_statistics
+  pal_statistics/pal_statistics_msgs:
+    type: git
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/jazzy/bookworm/pal_statistics_msgs

--- a/ros2_debian/ros-controls.jazzy.repos
+++ b/ros2_debian/ros-controls.jazzy.repos
@@ -35,6 +35,10 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/generate_parameter_library-release.git
     version: debian/jazzy/bookworm/generate_parameter_library
+  generate_parameter_library/parameter_traits:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/jazzy/bookworm/parameter_traits
   angles:
     type: git
     url: https://github.com/ros2-gbp/angles-release.git

--- a/ros2_debian/ros-controls.kilted.repos
+++ b/ros2_debian/ros-controls.kilted.repos
@@ -35,6 +35,10 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/generate_parameter_library-release.git
     version: debian/kilted/bookworm/generate_parameter_library
+  generate_parameter_library/parameter_traits:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/kilted/bookworm/parameter_traits
   angles:
     type: git
     url: https://github.com/ros2-gbp/angles-release.git

--- a/ros2_debian/ros-controls.kilted.repos
+++ b/ros2_debian/ros-controls.kilted.repos
@@ -2,52 +2,64 @@ repositories:
   ros/filters:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
-    version: debian/rolling/bookworm/filters
-  ros2-gbp/xacro:
+    version: debian/kilted/bookworm/filters
+  xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
-    version: debian/rolling/bookworm/xacro
-  ros2-gbp/diagnostic_updater:
+    version: debian/kilted/bookworm/xacro
+  diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
-    version: debian/rolling/bookworm/diagnostic_updater
+    version: debian/kilted/bookworm/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/rolling/bookworm/backward_ros
-  cpp_polyfills:
+    version: debian/kilted/bookworm/backward_ros
+  cpp_polyfills/tcb_span:
     type: git
-    url: https://github.com/PickNikRobotics/cpp_polyfills.git
-    version:  main
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/kilted/bookworm/tcb_span
+  cpp_polyfills/tl_expected:
+    type: git
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/kilted/bookworm/tl_expected
   rsl:
     type: git
-    url: https://github.com/PickNikRobotics/RSL.git
-    version:  main
-  generate_parameter_library:
+    url: https://github.com/ros2-gbp/RSL-release.git
+    version: debian/kilted/bookworm/rsl
+  generate_parameter_library/generate_parameter_library_py:
     type: git
-    url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version:  main
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/kilted/bookworm/generate_parameter_library_py
+  generate_parameter_library/generate_parameter_library:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/kilted/bookworm/generate_parameter_library
   angles:
     type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
+    url: https://github.com/ros2-gbp/angles-release.git
+    version: debian/kilted/bookworm/angles
   ackermann_msgs:
     type: git
-    url: https://github.com/ros-drivers/ackermann_msgs.git
-    version: ros2
+    url: https://github.com/ros2-gbp/ackermann_msgs-release.git
+    version: debian/kilted/bookworm/ackermann_msgs
   sdformat_urdf:
     type: git
-    url: https://github.com/ros/sdformat_urdf.git
-    version: rolling
-  gazebo-release/sdformat_vendor:
+    url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+    version: debian/kilted/bookworm/sdformat_urdf
+  sdformat_vendor:
     type: git
     url: https://github.com/gazebo-release/sdformat_vendor.git
-    version: rolling
-  gazebo-release/gz_tools_vendor:
+    version: kilted
+  gz_tools_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_tools_vendor.git
-    version: rolling
-  pal_statistics:
+    version: kilted
+  pal_statistics/pal_statistics:
     type: git
-    url: https://github.com/pal-robotics/pal_statistics.git
-    version: humble-devel
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/kilted/bookworm/pal_statistics
+  pal_statistics/pal_statistics_msgs:
+    type: git
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/kilted/bookworm/pal_statistics_msgs

--- a/ros2_debian/ros-controls.rolling.repos
+++ b/ros2_debian/ros-controls.rolling.repos
@@ -3,51 +3,63 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/filters-release.git
     version: debian/rolling/bookworm/filters
-  ros2-gbp/xacro:
+  xacro:
     type: git
     url: https://github.com/ros2-gbp/xacro-release.git
     version: debian/rolling/bookworm/xacro
-  ros2-gbp/diagnostic_updater:
+  diagnostic_updater:
     type: git
     url: https://github.com/ros2-gbp/diagnostics-release.git
     version: debian/rolling/bookworm/diagnostic_updater
   backward_ros:
     type: git
     url: https://github.com/ros2-gbp/backward_ros-release.git
-    version:  debian/rolling/bookworm/backward_ros
-  cpp_polyfills:
+    version: debian/rolling/bookworm/backward_ros
+  cpp_polyfills/tcb_span:
     type: git
-    url: https://github.com/PickNikRobotics/cpp_polyfills.git
-    version:  main
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/rolling/bookworm/tcb_span
+  cpp_polyfills/tl_expected:
+    type: git
+    url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+    version: debian/rolling/bookworm/tl_expected
   rsl:
     type: git
-    url: https://github.com/PickNikRobotics/RSL.git
-    version:  main
-  generate_parameter_library:
+    url: https://github.com/ros2-gbp/RSL-release.git
+    version: debian/rolling/bookworm/rsl
+  generate_parameter_library/generate_parameter_library_py:
     type: git
-    url: https://github.com/PickNikRobotics/generate_parameter_library.git
-    version:  main
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/rolling/bookworm/generate_parameter_library_py
+  generate_parameter_library/generate_parameter_library:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/rolling/bookworm/generate_parameter_library
   angles:
     type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
+    url: https://github.com/ros2-gbp/angles-release.git
+    version: debian/rolling/bookworm/angles
   ackermann_msgs:
     type: git
-    url: https://github.com/ros-drivers/ackermann_msgs.git
-    version: ros2
+    url: https://github.com/ros2-gbp/ackermann_msgs-release.git
+    version: debian/rolling/bookworm/ackermann_msgs
   sdformat_urdf:
     type: git
-    url: https://github.com/ros/sdformat_urdf.git
-    version: rolling
-  gazebo-release/sdformat_vendor:
+    url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+    version: debian/rolling/bookworm/sdformat_urdf
+  sdformat_vendor:
     type: git
     url: https://github.com/gazebo-release/sdformat_vendor.git
     version: rolling
-  gazebo-release/gz_tools_vendor:
+  gz_tools_vendor:
     type: git
     url: https://github.com/gazebo-release/gz_tools_vendor.git
     version: rolling
-  pal_statistics:
+  pal_statistics/pal_statistics:
     type: git
-    url: https://github.com/pal-robotics/pal_statistics.git
-    version: humble-devel
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/rolling/bookworm/pal_statistics
+  pal_statistics/pal_statistics_msgs:
+    type: git
+    url: https://github.com/ros2-gbp/pal_statistics-release.git
+    version: debian/rolling/bookworm/pal_statistics_msgs

--- a/ros2_debian/ros-controls.rolling.repos
+++ b/ros2_debian/ros-controls.rolling.repos
@@ -35,6 +35,10 @@ repositories:
     type: git
     url: https://github.com/ros2-gbp/generate_parameter_library-release.git
     version: debian/rolling/bookworm/generate_parameter_library
+  generate_parameter_library/parameter_traits:
+    type: git
+    url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+    version: debian/rolling/bookworm/parameter_traits
   angles:
     type: git
     url: https://github.com/ros2-gbp/angles-release.git


### PR DESCRIPTION
followup to #336 

we could also use rosinstall_generator to generate the repos file, but leave it hardcoded as of now