### PR TITLE
Use caching of setup-pixi and don't build tests

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -194,4 +194,4 @@ jobs:
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
             set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
           )
-          colcon build %up_to_arg% %skip_arg% %skip_ninja_arg% --event-handler console_cohesion+
+          colcon build %up_to_arg% %skip_arg% %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args -DBUILD_TESTING=OFF


### PR DESCRIPTION
This reduces the execution time of the windows workflow by more then 5 minutes:
https://github.com/ros-controls/control_msgs/actions/runs/15835200221/job/44656024001?pr=220
https://github.com/ros-controls/ros2_control/actions/runs/15857457875/job/44709498699?pr=2338

The gh action uses the pixi.lock file for calculating the hash for the cache, but it is not provided by ROS infrastructure (only the [manifest file is there](https://github.com/ros2/ros2/blob/rolling/pixi.toml)). I added a separate caching step for the lock file after the installation of the ROS base manifest, which itself gets patched by the given additional dependencies from the workflow call. 
Unless the versions from the pixi.toml or the dependencies are changed, the pixi cache should remain the same (which has a size of more than 1GB, with 10GB limit from our github plan).

Powershell code was partially generated by Copilot/GPT-4.1.