### PR TITLE
ICI: Use gh action for caching

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -134,8 +134,6 @@ jobs:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
       - name: Save ccache
         uses: actions/cache/save@v4
-        # only on default branch
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -96,8 +96,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref_for_scheduled_build }}
-      - name: cache ccache
-        uses: pat-s/always-upload-cache@v3.0.11
+      - name: Restore ccache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
@@ -132,6 +132,13 @@ jobs:
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
+      - name: Save ccache
+        uses: actions/cache/save@v4
+        # only on default branch
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
       - name: Download issue template for downstream failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -96,8 +96,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref_for_scheduled_build }}
-      - name: Restore ccache
-        uses: actions/cache/restore@v4
+      - name: Cache ccache folder
+        uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
@@ -132,11 +132,7 @@ jobs:
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O .github/issue_template_failed_ci.md
-      - name: Save ccache
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+
       - name: Download issue template for downstream failure  # Has to be a local file
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -88,10 +88,10 @@ jobs:
       BASEDIR: ${{ github.workspace }}/${{ inputs.basedir }}
       CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.upstream_workspace }}-${{ inputs.ros_repo }}-${{ github.job }}
     steps:
-      - name: Checkout ${{ inputs.ref }} when build is not scheduled
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} when build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
         uses: actions/checkout@v4
-      - name: Checkout ${{ inputs.ref }} on scheduled build
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
         if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v4
         with:
@@ -165,10 +165,3 @@ jobs:
         with:
           update_existing: true
           filename: .github/issue_template_failed_ci_downstream.md
-      - name: prepare target_ws for cache
-        if: ${{ always() && ! matrix.env.CCOV }}
-        run: |
-          du -sh ${{ env.BASEDIR }}/target_ws
-          sudo find ${{ env.BASEDIR }}/target_ws -wholename '*/test_results/*' -delete
-          sudo rm -rf ${{ env.BASEDIR }}/target_ws/src
-          du -sh ${{ env.BASEDIR }}/target_ws


### PR DESCRIPTION
Caching does not work for a while now: 
> Warning: Failed to restore: getCacheEntry failed: Cache service responded with 503

it seems that the pat-s's fork is not necessary any more, so I use original gh action now. Considering #384: I think (hope) that the ccache folder is not that big, so we can upload also caches from PRs.