### PR TITLE
Cache pixi.lock after its creation

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Restore pixi.lock
         uses: actions/cache/restore@v4
+        id: cache
         with:
           path: pixi.lock
           key: pixi|${{ inputs.ros_distro }}|${{ steps.hash.outputs.hash }}
@@ -126,6 +127,13 @@ jobs:
               Write-Host "No additional dependencies specified."
           }
 
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.8.10
+        # Cache pixi environment only on default branch to save disk space
+        with:
+          cache: true # default, only uses cache if pixi.lock is present
+          cache-write: ${{ steps.cache.outputs.cache-hit == 'true' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }} # only write cache on push to default branch to save disk space, caches from PRs can't be accessed anyways; only allowed if pixi.lock is present
+
       - name: Cache pixi.lock
         uses: actions/cache/save@v4
         # independent of the success of the following steps, but only on default branch
@@ -133,13 +141,6 @@ jobs:
         with:
           path: pixi.lock
           key: pixi|${{ inputs.ros_distro }}|${{ steps.hash.outputs.hash }}
-
-      - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
-        # Cache pixi environment only on default branch to save disk space
-        with:
-          cache: true # default, only uses cache if pixi.lock is present
-          cache-write: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }} # only write cache on push to default branch to save disk space, caches from PRs can't be accessed anyways
 
       - name: Upload pixi lock file
         uses: actions/upload-artifact@v4.6.2


### PR DESCRIPTION
Fix to #391 
two errors:
> Error: You cannot specify cache-write = true without a lock file present

and
```
Run actions/cache/save@v4
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
Warning: Cache save failed.
```
because it cache/save was on the wrong place