### PR TITLE
Make entrypoint executable

### DIFF
--- a/ros2_debian/Dockerfile.debian11
+++ b/ros2_debian/Dockerfile.debian11
@@ -152,8 +152,9 @@ COPY defaults.yaml /root/.colcon/defaults.yaml
 # there is no python3-graphviz on debian11, so install it via pip
 RUN pip3 install --no-cache-dir graphviz
 
-# set up sourcing of ros
+# Setup entrypoint (sourcing of ROS)
 COPY ./ros_entrypoint.sh /
+RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
 

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -158,8 +158,9 @@ COPY defaults.yaml /root/.colcon/defaults.yaml
 # there is no python3-graphviz on debian12, so install it via pip
 RUN pip3 install --no-cache-dir graphviz --break-system-packages
 
-# set up sourcing of ros
+# Setup entrypoint (sourcing of ROS)
 COPY ./ros_entrypoint.sh /
+RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
 

--- a/ros2_rhel/Dockerfile.rhel8
+++ b/ros2_rhel/Dockerfile.rhel8
@@ -59,8 +59,9 @@ COPY defaults.yaml /root/.colcon/defaults.yaml
 # there is no python3-graphviz on rhel8, so install it via pip
 RUN pip3 install --no-cache-dir graphviz
 
-# set up sourcing of ros
+# Setup entrypoint (sourcing of ROS)
 COPY ./ros_entrypoint.sh /
+RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
 

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -85,8 +85,9 @@ COPY defaults.yaml /root/.colcon/defaults.yaml
 # there is no python3-graphviz on rhel9, so install it via pip
 RUN pip3 install --no-cache-dir graphviz
 
-# set up sourcing of ros
+# Setup entrypoint (sourcing of ROS)
 COPY ./ros_entrypoint.sh /
+RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT [ "/ros_entrypoint.sh" ]
 CMD ["bash"]
 

--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -59,9 +59,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN rosdep init && \
     rosdep update --rosdistro $ROS_DISTRO
 
-# Setup entrypoint
+# Setup entrypoint (sourcing of ROS)
 COPY ./ros_entrypoint.sh /
-
+RUN chmod +x /ros_entrypoint.sh
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
 


### PR DESCRIPTION
otherwise we get
```
$ docker run -it --rm ghcr.io/ros-controls/ros:rolling-ubuntu-testing bash
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/ros_entrypoint.sh": permission denied: unknown
```
