### PR TITLE
Windows: Split upstream workspace from target workspace

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -61,7 +61,7 @@ jobs:
     container: ${{ inputs.container }}
     env:
       ros_underlay_path: C:\dev
-      upstream_workspace: C:\upstream
+      upstream_workspace: C:\upstream_ws
       # this will be src/{repo-owner}/{repo-name}
       repo_path: src/${{ github.repository }}
     steps:
@@ -173,21 +173,21 @@ jobs:
       - name: Clone dependencies
         # check for repos files, and pass them to vcstool
         run: |
-          mkdir -p ${{ env.upstream_workspace }}
-          Set-Location -Path ${{ env.upstream_workspace }}
+          mkdir -p ${{ env.upstream_workspace }}/src
           Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
           $repo_file = "${{ env.repo_path }}\${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos"
           if (Test-Path "$repo_file") {
             Write-Output "Local repos file found"
-            vcs import --input $repo_file src
+            vcs import --input $repo_file ${{ env.upstream_workspace }}/src
           }
           if (![string]::IsNullOrWhiteSpace("${{ inputs.windows_dependencies }}")) {
             $repo_file_win = "${{ env.repo_path }}\${{ inputs.windows_dependencies }}"
             if (Test-Path "$repo_file_win") {
               Write-Output "Windows repos file found"
-              vcs import --input $repo_file_win src
+              vcs import --input $repo_file_win ${{ env.upstream_workspace }}/src
             }
           }
+
       - name: Build upstream workspace
         # use Ninja generator optionally for selected packages.
         # This is needed for RSL, but doesn't work for msg packages
@@ -199,6 +199,8 @@ jobs:
           call pixi_env.bat >nul 2>&1
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
+
+          Set-Location -Path ${{ env.upstream_workspace }}
 
           set skip_ninja_arg=
           if not "${{ inputs.ninja_packages }}"=="" (

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -213,7 +213,6 @@ jobs:
             set skip_arg=%skip_arg% ${{ inputs.ninja_packages }}
           )
 
-          colcon list --packages-skip %skip_arg%
           colcon build --packages-skip %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }} --merge-install
 
       - name: Build target workspace
@@ -223,7 +222,6 @@ jobs:
           call pixi_env.bat >nul 2>&1
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
-          dir ${{ env.upstream_workspace }}
           call ${{ env.upstream_workspace }}\install\setup.bat
 
           @echo on

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -212,6 +212,8 @@ jobs:
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
             set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
           )
+
+          colcon list %skip_arg% %skip_ninja_arg%
           colcon build %skip_arg% %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
 
       - name: Build target workspace

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -43,8 +43,13 @@ on:
         default: ""
         required: false
         type: string
-      cmake_args:
-        description: "Additional arguments to pass to CMake, e.g. -DBUILD_TESTING=OFF"
+      upstream_cmake_args:
+        description: "Additional arguments to pass to CMake for upstream workspace, e.g. -DBUILD_TESTING=OFF"
+        default: "-DBUILD_TESTING=OFF"
+        required: false
+        type: string
+      target_cmake_args:
+        description: "Additional arguments to pass to CMake for target workspace, e.g. -DBUILD_TESTING=OFF"
         default: ""
         required: false
         type: string
@@ -200,7 +205,7 @@ jobs:
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
             set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
           )
-          colcon build %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args -DBUILD_TESTING=OFF
+          colcon build %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.target_cmake_args }}
 
       - name: Build target workspace
         shell: cmd
@@ -216,4 +221,4 @@ jobs:
           if not "${{ inputs.skip_packages }}"=="" (
             set skip_arg=--packages-skip ${{ inputs.skip_packages }}
           )
-          colcon build %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.cmake_args }}
+          colcon build %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.target_cmake_args }}

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -195,6 +195,7 @@ jobs:
         # https://github.com/colcon/colcon-ros/issues/84#issuecomment-1862881299
         shell: cmd
         run: |
+          @echo on
           call pixi shell-hook -s cmd > pixi_env.bat
           call pixi_env.bat >nul 2>&1
 
@@ -216,6 +217,7 @@ jobs:
       - name: Build target workspace
         shell: cmd
         run: |
+          @echo on
           call pixi shell-hook -s cmd > pixi_env.bat
           call pixi_env.bat >nul 2>&1
 

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -205,17 +205,16 @@ jobs:
 
           set skip_arg=
           if not "${{ inputs.skip_packages }}"=="" (
-            set skip_arg=--packages-skip ${{ inputs.skip_packages }}
+            set skip_arg=${{ inputs.skip_packages }}
           )
 
-          set skip_ninja_arg=
           if not "${{ inputs.ninja_packages }}"=="" (
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
-            set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
+            set skip_arg=%skip_arg% ${{ inputs.ninja_packages }}
           )
 
-          colcon list %skip_arg% %skip_ninja_arg%
-          colcon build %skip_arg% %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
+          colcon list --packages-skip %skip_arg%
+          colcon build --packages-skip %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
 
       - name: Build target workspace
         shell: cmd

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -201,12 +201,17 @@ jobs:
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
           pushd ${{ env.upstream_workspace }}
 
+          set skip_arg=
+          if not "${{ inputs.skip_packages }}"=="" (
+            set skip_arg=--packages-skip ${{ inputs.skip_packages }}
+          )
+
           set skip_ninja_arg=
           if not "${{ inputs.ninja_packages }}"=="" (
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
             set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
           )
-          colcon build %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
+          colcon build %skip_arg% %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
 
       - name: Build target workspace
         shell: cmd

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -199,7 +199,7 @@ jobs:
           call pixi_env.bat >nul 2>&1
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
-          cd ${{ env.upstream_workspace }}
+          pushd ${{ env.upstream_workspace }}
 
           set skip_ninja_arg=
           if not "${{ inputs.ninja_packages }}"=="" (

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -199,15 +199,14 @@ jobs:
           call pixi_env.bat >nul 2>&1
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
-
-          Set-Location -Path ${{ env.upstream_workspace }}
+          cd ${{ env.upstream_workspace }}
 
           set skip_ninja_arg=
           if not "${{ inputs.ninja_packages }}"=="" (
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
             set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
           )
-          colcon build %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.target_cmake_args }}
+          colcon build %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
 
       - name: Build target workspace
         shell: cmd

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -195,12 +195,13 @@ jobs:
         # https://github.com/colcon/colcon-ros/issues/84#issuecomment-1862881299
         shell: cmd
         run: |
-          @echo on
           call pixi shell-hook -s cmd > pixi_env.bat
           call pixi_env.bat >nul 2>&1
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
           pushd ${{ env.upstream_workspace }}
+
+          @echo on
 
           set skip_arg=
           if not "${{ inputs.skip_packages }}"=="" (
@@ -219,13 +220,14 @@ jobs:
       - name: Build target workspace
         shell: cmd
         run: |
-          @echo on
           call pixi shell-hook -s cmd > pixi_env.bat
           call pixi_env.bat >nul 2>&1
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
           dir ${{ env.upstream_workspace }}
           call ${{ env.upstream_workspace }}\install\setup.bat
+
+          @echo on
 
           set skip_arg=
           if not "${{ inputs.skip_packages }}"=="" (

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -56,6 +56,7 @@ jobs:
     container: ${{ inputs.container }}
     env:
       ros_underlay_path: C:\dev
+      upstream_workspace: C:\upstream
       # this will be src/{repo-owner}/{repo-name}
       repo_path: src/${{ github.repository }}
     steps:
@@ -164,9 +165,11 @@ jobs:
           path: ${{ env.repo_path }}
           manifest-path: pixi.toml
 
-      - name: Install dependencies
+      - name: Clone dependencies
         # check for repos files, and pass them to vcstool
         run: |
+          mkdir -p ${{ env.upstream_workspace }}
+          Set-Location -Path ${{ env.upstream_workspace }}
           Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
           $repo_file = "${{ env.repo_path }}\${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos"
           if (Test-Path "$repo_file") {
@@ -180,8 +183,7 @@ jobs:
               vcs import --input $repo_file_win src
             }
           }
-
-      - name: Build workspace
+      - name: Build upstream workspace
         # use Ninja generator optionally for selected packages.
         # This is needed for RSL, but doesn't work for msg packages
         # https://github.com/search?q=repo%3APickNikRobotics%2FRSL%20ninja&type=code
@@ -193,17 +195,25 @@ jobs:
 
           call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
 
-          set up_to_arg=
-          if not "${{ steps.package_list_action.outputs.package_list }}"=="" (
-            set up_to_arg=--packages-up-to ${{ steps.package_list_action.outputs.package_list }}
-          )
-          set skip_arg=
-          if not "${{ inputs.skip_packages }}"=="" (
-            set skip_arg=--packages-skip ${{ inputs.skip_packages }}
-          )
           set skip_ninja_arg=
           if not "${{ inputs.ninja_packages }}"=="" (
             colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
             set skip_ninja_arg=--packages-skip ${{ inputs.ninja_packages }}
           )
-          colcon build %up_to_arg% %skip_arg% %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.cmake_args }}
+          colcon build %skip_ninja_arg% --event-handler console_cohesion+ --cmake-args -DBUILD_TESTING=OFF
+
+      - name: Build target workspace
+        shell: cmd
+        run: |
+          call pixi shell-hook -s cmd > pixi_env.bat
+          call pixi_env.bat >nul 2>&1
+
+          call ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.bat
+          dir ${{ env.upstream_workspace }}
+          call ${{ env.upstream_workspace }}\install\setup.bat
+
+          set skip_arg=
+          if not "${{ inputs.skip_packages }}"=="" (
+            set skip_arg=--packages-skip ${{ inputs.skip_packages }}
+          )
+          colcon build %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.cmake_args }}

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -209,12 +209,12 @@ jobs:
           )
 
           if not "${{ inputs.ninja_packages }}"=="" (
-            colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+
+            colcon build --packages-up-to ${{ inputs.ninja_packages }} --cmake-args -G Ninja --event-handler console_cohesion+ --merge-install
             set skip_arg=%skip_arg% ${{ inputs.ninja_packages }}
           )
 
           colcon list --packages-skip %skip_arg%
-          colcon build --packages-skip %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }}
+          colcon build --packages-skip %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.upstream_cmake_args }} --merge-install
 
       - name: Build target workspace
         shell: cmd
@@ -232,4 +232,4 @@ jobs:
           if not "${{ inputs.skip_packages }}"=="" (
             set skip_arg=--packages-skip ${{ inputs.skip_packages }}
           )
-          colcon build %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.target_cmake_args }}
+          colcon build %skip_arg% --event-handler console_cohesion+ --cmake-args ${{ inputs.target_cmake_args }} --merge-install


### PR DESCRIPTION
so we can add different cmake args for example.

Fixed also a bug with skip-packages arguments: colcon only uses the last one, and does not merge them if --packages-skip is given multiple times.