### PR TITLE
check for empty .repos file to avoid vcs crashing

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -70,20 +70,17 @@ jobs:
 
       # Run the generator and output the results to a file with retry logic.
       - name: Use rosinstall_generator to get all dependencies
+        id: check_deps_file
         run: |
           for i in {1..5}; do
             rosinstall_generator ${{ steps.package_list_action.outputs.package_list }} --rosdistro ${{ inputs.ros_distro }} \
             --deps-only --deps --upstream-development > /tmp/deps.repos && break || echo "retry #${i} .." && sleep 60;
           done
-
-      - name: Check if dependency file is empty
-        id: check_deps_file
-        run: |
           if [ -s /tmp/deps.repos ]; then
             echo "vcs_file_path=/tmp/deps.repos" >> $GITHUB_OUTPUT
           else
             echo "vcs_file_path=" >> $GITHUB_OUTPUT
-          fi
+          fi          
 
       - uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -76,14 +76,22 @@ jobs:
             --deps-only --deps --upstream-development > /tmp/deps.repos && break || echo "retry #${i} .." && sleep 60;
           done
 
+      - name: Check if dependency file is empty
+        id: check_deps_file
+        run: |
+          if [ -s /tmp/deps.repos ]; then
+            echo "vcs_file_path=/tmp/deps.repos" >> $GITHUB_OUTPUT
+          else
+            echo "vcs_file_path=" >> $GITHUB_OUTPUT
+          fi
+
       - uses: ros-tooling/action-ros-ci@0.4.5
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}
           ref: ${{ inputs.ref }}
           package-name: ${{ steps.package_list_action.outputs.package_list }}
           rosdep-skip-keys: rti-connext-dds-7.3.0
-          vcs-repo-file-url: |
-            /tmp/deps.repos
+          vcs-repo-file-url: ${{ steps.check_deps_file.outputs.vcs_file_path }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon-defaults: |
             {

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -80,7 +80,7 @@ jobs:
             echo "vcs_file_path=/tmp/deps.repos" >> $GITHUB_OUTPUT
           else
             echo "vcs_file_path=" >> $GITHUB_OUTPUT
-          fi          
+          fi
 
       - uses: ros-tooling/action-ros-ci@0.4.5
         with:


### PR DESCRIPTION
I've been using `reusable-ros-tooling-source-build.yml` workflow directly from this repo, but as my package has no dependencies declared in `package.xml`, the `.repos` file generated by `rosinstall_generator` is empty, causing `vcs import` to crash:

```
Invoking: bash -c,vcs import --force --recursive src/ --input file:///tmp/deps.repos
  /usr/bin/bash -c vcs import --force --recursive src/ --input file:///tmp/deps.repos
  /usr/bin/vcs:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import load_entry_point
  Input data is not valid format: 'NoneType' object is not subscriptable
Error: The process '/usr/bin/bash' failed with exit code 1
```

## Solution:
Added a step which, if the generated `.repos` file is empty, passes an empty string to `ros-tooling/action-ros-ci@0.4.5` action.
This action then ignores the `vcs` call and proceeds.

```
- name: Check if dependency file is empty
        id: check_deps_file
        run: |
          if [ -s /tmp/deps.repos ]; then
            echo "vcs_file_path=/tmp/deps.repos" >> $GITHUB_OUTPUT
          else
            echo "vcs_file_path=" >> $GITHUB_OUTPUT
          fi
```

[Now my CI workflow succeeeds](https://github.com/b-robotized/ads_vendor/actions/runs/17790489221/job/50566190383), skipping this call completely:
```
Invoking: bash -c,vcs import --force --recursive src/ --input file:///tmp/deps.repos
```

## Why merge this PR?
It is a change that makes `ros2_control_ci` more robust without affecting any existing CI workflows.