### PR TITLE
Use rosinstall generator for windows workflow

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -191,6 +191,7 @@ jobs:
           $pkg_list=$(ros2 pkg list)
           echo "Packages in ROS installation: $pkg_list"
           rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $pkg_list ${{ steps.package_list_action.outputs.package_list }} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
+          cat deps.repos
           vcs import --input deps.repos ${{ env.upstream_workspace }}/src
 
       - name: Build upstream workspace

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -91,7 +91,7 @@ jobs:
           irm https://raw.githubusercontent.com/ros2/ros2/refs/heads/rolling/pixi.toml -OutFile $manifest
 
           # patch pixi.toml to add extra dependencies
-          $deps = "${{ inputs.pixi_dependencies }}"
+          $deps = "${{ inputs.pixi_dependencies }} rosinstall_generator"
           if (-not [string]::IsNullOrWhiteSpace($deps)) {
             Write-Host "Extra dependencies specified: $deps"
 
@@ -180,13 +180,12 @@ jobs:
             Write-Output "Local repos file found"
             vcs import --input $repo_file ${{ env.upstream_workspace }}/src
           }
-          if (![string]::IsNullOrWhiteSpace("${{ inputs.windows_dependencies }}")) {
-            $repo_file_win = "${{ env.repo_path }}\${{ inputs.windows_dependencies }}"
-            if (Test-Path "$repo_file_win") {
-              Write-Output "Windows repos file found"
-              vcs import --input $repo_file_win ${{ env.upstream_workspace }}/src
-            }
-          }
+
+          ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.ps1
+          $pkg_list=$(ros2 pkg list)
+          echo "Packages in ROS installation: $pkg_list"
+          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $pkg_list ${{ steps.package_list_action.outputs.repo_name }} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
+          vcs import --input deps.repos ${{ env.upstream_workspace }}/src
 
       - name: Build upstream workspace
         # use Ninja generator optionally for selected packages.

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -24,7 +24,7 @@ on:
         default: ""
         type: string
       pixi_dependencies:
-        description: "Whitespace separated list of additional pixi dependencies"
+        description: "Space-separated list of additional pixi dependencies"
         required: false
         default: ""
         type: string
@@ -33,13 +33,18 @@ on:
         required: false
         default: ""
         type: string
+      skip_dependencies:
+        description: "Space-separated list of packages to skip from rosinstall_generator dependency resolution"
+        default: "sdformat_urdf"
+        required: false
+        type: string
       skip_packages:
-        description: "Packages to skip from build"
+        description: "Space-separated list of packages to skip from build"
         default: ""
         required: false
         type: string
       ninja_packages:
-        description: "Packages to be built with Ninja generator (default is MSVC otherwise)"
+        description: "Space-separated list of packages to be built with Ninja generator (default is MSVC otherwise)"
         default: ""
         required: false
         type: string
@@ -198,7 +203,7 @@ jobs:
           Write-Host "Packages in ROS installation: $underlay_ws_pkgs"
           $upstream_ws_pkgs=($(colcon list --names-only --paths ${{ env.upstream_workspace }}/src/*/**) -join " ")
           Write-Host "Packages in upstream workspace: $upstream_ws_pkgs"
-          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $underlay_ws_pkgs ${{ steps.package_list_action.outputs.package_list }} $upstream_ws_pkgs --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
+          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $underlay_ws_pkgs ${{ steps.package_list_action.outputs.package_list }} $upstream_ws_pkgs ${{inputs.skip_dependencies}} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
           cat deps.repos
           # rosinstall_generator skips excludes with are from a different repo (gbp instead of development repo)
           vcs import --skip-existing --input deps.repos ${{ env.upstream_workspace }}/src

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -194,9 +194,11 @@ jobs:
           }
 
           # use rosinstall_generator to get all dependencies which are not yet installed
-          $pkg_list=$(ros2 pkg list)
-          Write-Host "Packages in ROS installation: $pkg_list"
-          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $pkg_list ${{ steps.package_list_action.outputs.package_list }} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
+          $underlay_ws_pkgs=$(ros2 pkg list)
+          Write-Host "Packages in ROS installation: $underlay_ws_pkgs"
+          $upstream_ws_pkgs=($(colcon list --names-only --paths ${{ env.upstream_workspace }}/src/*/**) -join " ")
+          Write-Host "Packages in underlay workspace: $upstream_ws_pkgs"
+          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $underlay_ws_pkgs ${{ steps.package_list_action.outputs.package_list }} $upstream_ws_pkgs --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
           cat deps.repos
           vcs import --input deps.repos ${{ env.upstream_workspace }}/src
 

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -190,7 +190,7 @@ jobs:
           ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.ps1
           $pkg_list=$(ros2 pkg list)
           echo "Packages in ROS installation: $pkg_list"
-          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $pkg_list ${{ steps.package_list_action.outputs.repo_name }} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
+          rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $pkg_list ${{ steps.package_list_action.outputs.package_list }} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
           vcs import --input deps.repos ${{ env.upstream_workspace }}/src
 
       - name: Build upstream workspace

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -156,6 +156,9 @@ jobs:
         # Download and extract ROS 2 package
         # https://docs.ros.org/en/rolling/Installation/Windows-Install-Binary.html
         run: |
+          # TODO(christophfroehlich) remove with fix below
+          Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
+
           mkdir -p ${{ env.ros_underlay_path }}
           Set-Location -Path ${{ env.ros_underlay_path }}
           $url = "https://ci.ros2.org/view/packaging/job/packaging_windows/lastSuccessfulBuild/artifact/ws/ros2-package-windows-AMD64.zip"
@@ -165,7 +168,6 @@ jobs:
 
           # python packages are broken: https://github.com/ros2/ros2/issues/1675
           # TODO(christophfroehlich) remove once https://github.com/ros2/ci/pull/817 is released
-          Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
           cd ros2_${{ inputs.ros_distro }}
           irm https://gist.githubusercontent.com/knmcguire/fd5326de442289712539182f6257191c/raw/bcb4bf2a460af3a1d71bcfcdcefa065ebd5060d7/preinstall_setup_windows.py -OutFile preinstall_setup_windows.py
           python preinstall_setup_windows.py

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -165,6 +165,7 @@ jobs:
 
           # python packages are broken: https://github.com/ros2/ros2/issues/1675
           # TODO(christophfroehlich) remove once https://github.com/ros2/ci/pull/817 is released
+          Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
           cd ros2_${{ inputs.ros_distro }}
           irm https://gist.githubusercontent.com/knmcguire/fd5326de442289712539182f6257191c/raw/bcb4bf2a460af3a1d71bcfcdcefa065ebd5060d7/preinstall_setup_windows.py -OutFile preinstall_setup_windows.py
           python preinstall_setup_windows.py
@@ -177,19 +178,22 @@ jobs:
           manifest-path: pixi.toml
 
       - name: Clone dependencies
-        # check for repos files, and pass them to vcstool
         run: |
-          mkdir -p ${{ env.upstream_workspace }}/src
+          Set-PSDebug -Trace 1 # Enabling verbose output (equivalent to @echo on)
           Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
+          ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.ps1
+
+          # check for repos files, and pass them to vcstool
+          mkdir -p ${{ env.upstream_workspace }}/src
           $repo_file = "${{ env.repo_path }}\${{ steps.package_list_action.outputs.repo_name }}.${{ inputs.ros_distro }}.repos"
           if (Test-Path "$repo_file") {
             Write-Output "Local repos file found"
             vcs import --input $repo_file ${{ env.upstream_workspace }}/src
           }
 
-          ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.ps1
+          # use rosinstall_generator to get all dependencies which are not yet installed
           $pkg_list=$(ros2 pkg list)
-          echo "Packages in ROS installation: $pkg_list"
+          Write-Host "Packages in ROS installation: $pkg_list"
           rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $pkg_list ${{ steps.package_list_action.outputs.package_list }} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
           cat deps.repos
           vcs import --input deps.repos ${{ env.upstream_workspace }}/src

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -196,6 +196,13 @@ jobs:
             Write-Output "Local repos file found"
             vcs import --input $repo_file ${{ env.upstream_workspace }}/src
           }
+          if (![string]::IsNullOrWhiteSpace("${{ inputs.windows_dependencies }}")) {
+            $repo_file_win = "${{ env.repo_path }}\${{ inputs.windows_dependencies }}"
+            if (Test-Path "$repo_file_win") {
+              Write-Output "Windows repos file found"
+              vcs import --input $repo_file_win ${{ env.upstream_workspace }}/src
+            }
+          }
 
           # use rosinstall_generator to get all dependencies which are not yet installed
           $underlay_ws_pkgs=$(ros2 pkg list)

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -197,10 +197,11 @@ jobs:
           $underlay_ws_pkgs=$(ros2 pkg list)
           Write-Host "Packages in ROS installation: $underlay_ws_pkgs"
           $upstream_ws_pkgs=($(colcon list --names-only --paths ${{ env.upstream_workspace }}/src/*/**) -join " ")
-          Write-Host "Packages in underlay workspace: $upstream_ws_pkgs"
+          Write-Host "Packages in upstream workspace: $upstream_ws_pkgs"
           rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $underlay_ws_pkgs ${{ steps.package_list_action.outputs.package_list }} $upstream_ws_pkgs --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
           cat deps.repos
-          vcs import --input deps.repos ${{ env.upstream_workspace }}/src
+          # rosinstall_generator skips excludes with are from a different repo (gbp instead of development repo)
+          vcs import --skip-existing --input deps.repos ${{ env.upstream_workspace }}/src
 
       - name: Build upstream workspace
         # use Ninja generator optionally for selected packages.

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -163,6 +163,12 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile $output
           Expand-Archive -Path $output -DestinationPath ros2_${{ inputs.ros_distro }}
 
+          # python packages are broken: https://github.com/ros2/ros2/issues/1675
+          # TODO(christophfroehlich) remove once https://github.com/ros2/ci/pull/817 is released
+          cd ros2_${{ inputs.ros_distro }}
+          irm https://gist.githubusercontent.com/knmcguire/fd5326de442289712539182f6257191c/raw/bcb4bf2a460af3a1d71bcfcdcefa065ebd5060d7/preinstall_setup_windows.py -OutFile preinstall_setup_windows.py
+          python preinstall_setup_windows.py
+
       - name: Get package list
         id: package_list_action
         uses: ros-controls/ros2_control_ci/.github/actions/set-package-list-pixi@master

--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -186,7 +186,6 @@ jobs:
 
       - name: Clone dependencies
         run: |
-          Set-PSDebug -Trace 1 # Enabling verbose output (equivalent to @echo on)
           Invoke-Expression ((& pixi shell-hook -s powershell) -join "`n")
           ${{ env.ros_underlay_path }}\ros2_${{ inputs.ros_distro }}\ros2-windows\setup.ps1
 
@@ -200,11 +199,10 @@ jobs:
 
           # use rosinstall_generator to get all dependencies which are not yet installed
           $underlay_ws_pkgs=$(ros2 pkg list)
-          Write-Host "Packages in ROS installation: $underlay_ws_pkgs"
+          # Write-Host "Packages in ROS installation: $underlay_ws_pkgs"
           $upstream_ws_pkgs=($(colcon list --names-only --paths ${{ env.upstream_workspace }}/src/*/**) -join " ")
-          Write-Host "Packages in upstream workspace: $upstream_ws_pkgs"
+          # Write-Host "Packages in upstream workspace: $upstream_ws_pkgs"
           rosinstall_generator --rosdistro ${{ inputs.ros_distro }} --deps --format repos --exclude $underlay_ws_pkgs ${{ steps.package_list_action.outputs.package_list }} $upstream_ws_pkgs ${{inputs.skip_dependencies}} --from-path ${{ env.upstream_workspace }} ${{ env.repo_path }} > deps.repos
-          cat deps.repos
           # rosinstall_generator skips excludes with are from a different repo (gbp instead of development repo)
           vcs import --skip-existing --input deps.repos ${{ env.upstream_workspace }}/src
 


### PR DESCRIPTION
We need to patch the ROS installation, otherwise python scripts don't work (like ros2cli).