### PR TITLE
Also install python3-osrf-pycommon

### DIFF
--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -170,7 +170,10 @@ RUN \
   fi && \
   if [ $ROS_DISTRO = "rolling" ]; then \
     apt-get update -y -qq && \
-    apt-get -y install --no-install-recommends liborocos-kdl-dev liborocos-kdl1.5 ;\
+    # we don't want to install all system dependencies for ros2.repos
+    # https://github.com/ros2/geometry2/pull/826
+    # https://github.com/ros2/launch/pull/817
+    apt-get -y install --no-install-recommends liborocos-kdl-dev liborocos-kdl1.5 python3-osrf-pycommon ;\
   fi && \
   # build source, ROS core
   colcon build \


### PR DESCRIPTION
Fix missing system dependency

```
   <<< failure message
    -- run_test.py: extra environment variables:
     - PYTHONDONTWRITEBYTECODE=1
    -- run_test.py: invoking following command in '/__w/topic_based_hardware_interfaces/topic_based_hardware_interfaces/build/joint_state_topic_hardware_interface':
     - /opt/ros2_ws/install/rmw_test_fixture_implementation/lib/rmw_test_fixture_implementation/run_rmw_isolated /usr/bin/python3 -m launch_testing.launch_test /__w/topic_based_hardware_interfaces/topic_based_hardware_interfaces/src/ros-controls/topic_based_hardware_interfaces/joint_state_topic_hardware_interface/test/rrr/position.test.py --junit-xml=/__w/topic_based_hardware_interfaces/topic_based_hardware_interfaces/build/joint_state_topic_hardware_interface/test_results/joint_state_topic_hardware_interface/test_rrr_position.test.py.xunit.xml --package-name=joint_state_topic_hardware_interface
    Traceback (most recent call last):
      File "<frozen runpy>", line 189, in _run_module_as_main
      File "<frozen runpy>", line 112, in _get_module_details
      File "/opt/ros2_ws/install/launch_testing/lib/python3.11/site-packages/launch_testing/__init__.py", line 15, in <module>
        from . import tools
      File "/opt/ros2_ws/install/launch_testing/lib/python3.11/site-packages/launch_testing/tools/__init__.py", line 15, in <module>
        from .output import basic_output_filter
      File "/opt/ros2_ws/install/launch_testing/lib/python3.11/site-packages/launch_testing/tools/output.py", line 19, in <module>
        from osrf_pycommon.terminal_color import remove_ansi_escape_sequences
    ModuleNotFoundError: No module named 'osrf_pycommon'
    -- run_test.py: return code 1
```