### PR TITLE
docs: fix reviewers lottery typo

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,6 +1,6 @@
 groups:
   # Default reviewers for all pull requests.
-  # Usually, at least on of the maintainers should approve PR before merging.
+  # Usually, at least one of the maintainers should approve PR before merging.
   # The best is if two maintainers do that.
   - name: maintainers # name of the group
     reviewers: 2 # how many reviewers do you want to assign?


### PR DESCRIPTION
Hello respected maintainers and reviewers!
This is Surya!

This PR fixes a small typo in the reviewers lottery file.

I was just looking in the workflows of ros2_controllers where I found this typo.