### PR TITLE
Skip rmw_zenoh_cpp from being installed as binary

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -115,7 +115,8 @@ jobs:
         if: ${{ always() && steps.action-ros.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci.md -O ${{ env.repo_path }}/.github/issue_template_failed_ci.md
-      - uses: JasonEtco/create-an-issue@v2
+      - name: Create an issue on failure
+        uses: JasonEtco/create-an-issue@v2
         # action-ros-ci does not report more details on test failures afaik
         if: ${{ always() && steps.action-ros.outcome == 'failure' && github.event_name == 'schedule'}}
         env:


### PR DESCRIPTION
Source build was broken, see history https://github.com/ros2/rosidl/issues/932
Could be removed after next tag/release of rmw_implementation, but it just will have no effect then once it is pulled from rosinstall_generator.

Also added an upload of the repos file.

Tested with https://github.com/ros-controls/control_toolbox/actions/runs/21703751490/job/62725213238?pr=565