### PR TITLE
Install libyaml-dev on debian

### DIFF
--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -44,6 +44,7 @@ RUN apt-get update -y -qq && \
   libssl-dev \
   libtinyxml-dev \
   libtinyxml2-dev \
+  libyaml-dev \
   lsb-release \
   lttng-tools \
   mlocate \


### PR DESCRIPTION
libyaml_vendor changed with https://github.com/ros2/libyaml_vendor/pull/67/changes