### PR TITLE
Fix path for cl_wrapper

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -88,7 +88,6 @@ jobs:
       repo_path: src/${{ github.repository }}
       tooling_repo_path: src/ros-controls/ros2_control_ci
       CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}
-      CCACHE_LOGFILE: ${{ github.workspace }}/ccache.log
       CACHE_PREFIX: win-${{ inputs.ros_distro }}-${{ inputs.target_workspace }}-${{ github.job }}
       CCACHE_MSVC: "1"
     steps:
@@ -213,8 +212,6 @@ jobs:
           echo with content:
           type "%CCACHE_WRAPPER_WIN%"
           echo end CCACHE_WRAPPER%
-
-          if exist "${{ env.CCACHE_LOGFILE }}" del /f /q "${{ env.CCACHE_LOGFILE }}"
 
           ccache --show-config
           ccache --zero-stats
@@ -363,20 +360,6 @@ jobs:
 
           ccache --show-stats --verbose
 
-          echo ===== CMake compiler entries (upstream build) =====
-          for /r "${{ env.upstream_workspace }}\build" %%F in (CMakeCache.txt) do (
-            echo [%%F]
-            findstr /R /C:"^CMAKE_C_COMPILER:FILEPATH=" /C:"^CMAKE_CXX_COMPILER:FILEPATH=" "%%F"
-          )
-
-          echo ===== CCACHE_LOGFILE =====
-          echo Path: ${{ env.CCACHE_LOGFILE }}
-          if exist "${{ env.CCACHE_LOGFILE }}" (
-            powershell -NoProfile -Command "Get-Content -Path '${{ env.CCACHE_LOGFILE }}' -Tail 200"
-          ) else (
-            echo CCACHE_LOGFILE not found
-          )
-
       - name: Build target workspace
         id: build_target_workspace
         shell: cmd
@@ -413,20 +396,6 @@ jobs:
           call pixi_env.bat >nul 2>&1
 
           ccache --show-stats --verbose
-
-          echo ===== CMake compiler entries (target build) =====
-          for /r "${{ env.target_workspace }}\build" %%F in (CMakeCache.txt) do (
-            echo [%%F]
-            findstr /R /C:"^CMAKE_C_COMPILER:FILEPATH=" /C:"^CMAKE_CXX_COMPILER:FILEPATH=" "%%F"
-          )
-
-          echo ===== CCACHE_LOGFILE =====
-          echo Path: ${{ env.CCACHE_LOGFILE }}
-          if exist "${{ env.CCACHE_LOGFILE }}" (
-            powershell -NoProfile -Command "Get-Content -Path '${{ env.CCACHE_LOGFILE }}' -Tail 200"
-          ) else (
-            echo CCACHE_LOGFILE not found
-          )
 
       - name: Save ccache folder
         if: ${{ always() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.build_target_workspace.outcome == 'success' }}


### PR DESCRIPTION
Earlier the init ccache step gave:
```
CCACHE wrapper created at: D:/a/_temp/cl_wrapper.bat
The system cannot find the file specified.
```

Now the caching works at least a bit

```
Cache directory:               D:\a\ros2_control_ci\ros2_control_ci/.ccache
Config file:                   D:\a\ros2_control_ci\ros2_control_ci\.ccache\ccache.conf
System config file:            C:\ProgramData\ccache\ccache.conf
Stats updated:                 Thu Mar 12 16:00:11 2026
Cacheable calls:                 4 /  19 (21.05%)
  Hits:                          1 /   4 (25.00%)
    Direct:                      1 /   1 (100.0%)
    Preprocessed:                0 /   1 ( 0.00%)
  Misses:                        3 /   4 (75.00%)
Uncacheable calls:              15 /  19 (78.95%)
  Called for linking:            4 /  15 (26.67%)
  Unsupported compiler option:  11 /  15 (73.33%)
Successful lookups:
  Direct:                        1 /   4 (25.00%)
  Preprocessed:                  0 /   3 ( 0.00%)
Local storage:
  Cache size (GiB):            0.0 / 5.0 ( 0.00%)
  Files:                         6
  Hits:                          1 /   4 (25.00%)
  Misses:                        3 /   4 (75.00%)
  Reads:                         8
  Writes:                        6
```
