### PR TITLE
Win: Skip pinocchio only if it exists

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -332,10 +332,12 @@ jobs:
             set skip_arg=%skip_arg% ${{ inputs.ninja_packages }}
           )
 
-          set pinocchio_present=0
+          colcon list --names-only
           colcon list --names-only | findstr /R /C:"^pinocchio$" >nul
           if errorlevel 2 exit /b 1
-          if errorlevel 0 (
+          if errorlevel 1 (
+            set pinocchio_present=0
+          ) else (
             @echo skip pinocchio in the main build and build it separately with different cmake args
             set skip_arg=%skip_arg% pinocchio
             set pinocchio_present=1


### PR DESCRIPTION
In this repo, pinocchio is present and will be built.

Here is an example what happens if pinocchio is not present: https://github.com/PickNikRobotics/cpp_polyfills/actions/runs/23460976017/job/68348197114