### PR TITLE
Fix typo in dockerfile

### DIFF
--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -115,7 +115,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # colcon-devtools>0.2.3 is not released for debian12, so override it with pip
   # typing_extensions needs to be >4.7.0, but is available on apt with 4.4.0 only
   apt-get remove -y python3-colcon-devtools && \
-  pip3 install --no-cache-dir colcon-devtools typing_extensions --break-system-package && \
+  pip3 install --no-cache-dir colcon-devtools typing_extensions --break-system-packages && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
 

--- a/ros2_debian/Dockerfile.debian12
+++ b/ros2_debian/Dockerfile.debian12
@@ -113,9 +113,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-mypy \
   && \
   # colcon-devtools>0.2.3 is not released for debian12, so override it with pip
-  # typing_extensions needs to be >4.7.0, but is available on apt with 4.4.0 only
   apt-get remove -y python3-colcon-devtools && \
-  pip3 install --no-cache-dir colcon-devtools typing_extensions --break-system-packages && \
+  pip3 install --no-cache-dir colcon-devtools --break-system-packages && \
+  # typing_extensions needs to be >4.7.0, but is available on apt with 4.4.0 only
+  pip3 install --no-cache-dir --upgrade typing_extensions --break-system-packages && \
   : "remove cache" && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Wrong version of typing_extensions is installed
```
2026-04-20T09:39:56.0943782Z <<< error message
2026-04-20T09:39:56.0943875Z The test did not generate a result file:
2026-04-20T09:39:56.0943936Z
2026-04-20T09:39:56.0944100Z usage: launch_test.py [-h] [--package-name PACKAGE_NAME] [-v] [-s]
2026-04-20T09:39:56.0944182Z [--junit-xml XMLPATH]
2026-04-20T09:39:56.0944293Z launch_test_file [launch_arguments ...]
2026-04-20T09:39:56.0944672Z launch_test.py: error: cannot import name 'deprecated' from 'typing_extensions' (/usr/lib/python3/dist-packages/typing_extensions.py)
```