### PR TITLE
fix(rhel9): Simlify pinocchio to be built successfully again

### DIFF
--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -42,7 +42,7 @@ jobs:
             source_packages: pinocchio
           - ros_distro: rolling
             rhel_version: rhel9
-            source_packages: pinocchio
+            source_packages: pinocchio hpp-fcl
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -42,7 +42,7 @@ jobs:
             source_packages: pinocchio
           - ros_distro: rolling
             rhel_version: rhel9
-            source_packages: pinocchio hpp-fcl
+            source_packages: pinocchio
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -107,7 +107,7 @@ RUN \
   # build pinocchio from source
   colcon build \
     --mixin release build-testing-off \
-    --cmake-args --no-warn-unused-cli -DBUILD_EXAMPLES=OFF -DBUILD_PYTHON_INTERFACE=OFF \
+    --cmake-args --no-warn-unused-cli -DBUILD_EXAMPLES=OFF -DBUILD_PYTHON_INTERFACE=OFF -DBUILD_WITH_HPP_FCL_SUPPORT=OFF -DBUILD_WITH_COLLISION_SUPPORT=OFF \
     --packages-select pinocchio && \
   # cleanup
   rm -rf log src build


### PR DESCRIPTION
Should fix
`2026-04-28T19:15:52.3500357Z #18 12.38 pinocchio: No definition of [hpp-fcl] for OS version [9]`
in https://github.com/ros-controls/ros2_control_ci/actions/runs/25072436610/attempts/2