### PR TITLE
Create an issue if build_*_workspace output is nonzero

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -157,10 +157,11 @@ jobs:
         if: ${{ always() && steps.ici.outcome == 'failure' && github.event_name == 'schedule' }}
         run:
           wget https://raw.githubusercontent.com/ros-controls/ros2_control_ci/master/.github/issue_template_failed_ci_downstream.md -O .github/issue_template_failed_ci_downstream.md
-      - uses: JasonEtco/create-an-issue@v2
+      - name: Create issue on failure (target workspace)
+        uses: JasonEtco/create-an-issue@v2
         # `make` and so `colcon build` returns 2 on errors, while `colcon test-result` returns 1 on
         # when any test failed.
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule'}}
+        if: ${{ always() && (fromJSON(steps.ici.outputs.build_target_workspace) > 0 || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -169,8 +170,9 @@ jobs:
         with:
           update_existing: true
           filename: .github/issue_template_failed_ci.md
-      - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_downstream_workspace == '2' || steps.ici.outputs.downstream_test_results == '1') && github.event_name == 'schedule'}}
+      - name: Create issue on failure (downstream workspace)
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ always() && (fromJSON(steps.ici.outputs.build_downstream_workspace) > 0 || steps.ici.outputs.downstream_test_results == '1') && github.event_name == 'schedule'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -161,7 +161,7 @@ jobs:
         uses: JasonEtco/create-an-issue@v2
         # `make` and so `colcon build` returns 2 on errors, while `colcon test-result` returns 1 on
         # when any test failed.
-        if: ${{ always() && (fromJSON(steps.ici.outputs.build_target_workspace) > 0 || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule' }}
+        if: ${{ always() && ((steps.ici.outputs.build_target_workspace != '' && fromJSON(steps.ici.outputs.build_target_workspace) > 0) || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}
@@ -172,7 +172,7 @@ jobs:
           filename: .github/issue_template_failed_ci.md
       - name: Create issue on failure (downstream workspace)
         uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (fromJSON(steps.ici.outputs.build_downstream_workspace) > 0 || steps.ici.outputs.downstream_test_results == '1') && github.event_name == 'schedule'}}
+        if: ${{ always() && ((steps.ici.outputs.build_downstream_workspace != '' && fromJSON(steps.ici.outputs.build_downstream_workspace) > 0) || steps.ici.outputs.downstream_test_results == '1') && github.event_name == 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTION_NAME: ${{ inputs.ros_distro }}/${{ inputs.ros_repo }}


### PR DESCRIPTION
https://github.com/ros-controls/ros2_control_ci/actions/runs/25090920855/job/73516695917
build fails, but with return code 1
> 'build_target_workspace' returned with code '1' after 0 min 38 sec

An issue should be created for any nonzero return code?