### PR TITLE
Pin ubuntu to `resolute` for rolling

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -123,7 +123,7 @@ jobs:
           else
             echo "DOCKER_IMAGE=ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-ubuntu-testing${{ inputs.docker_image_tag_suffix }}" >> $GITHUB_OUTPUT
           fi
-      - uses: 'ros-industrial/industrial_ci@master'
+      - uses: 'mathias-luedtke/industrial_ci@feature/rolling-resolute'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
           TARGET_WORKSPACE: ${{ inputs.target_workspace }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -132,7 +132,8 @@ jobs:
           NOT_TEST_DOWNSTREAM: ${{ inputs.not_test_downstream }}
           DOCKER_IMAGE: ${{ steps.docker_image.outputs.DOCKER_IMAGE }}
           ROS_REPO: ${{ inputs.ros_repo }}
-          OS_CODE_NAME: ${{ inputs.os_code_name }}
+          # TODO(christophfroehlich): revert this change once https://github.com/ros-industrial/industrial_ci/pull/935 is merged
+          OS_CODE_NAME: ${{ inputs.ros_distro == 'rolling' && 'resolute' || inputs.os_code_name }}
           ROSDEP_SKIP_KEYS: ${{ inputs.rosdep_skip_keys }}
           ADDITIONAL_DEBS: ${{ inputs.additional_debs }}
           CC: ${{ inputs.c_compiler }}

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -123,7 +123,7 @@ jobs:
           else
             echo "DOCKER_IMAGE=ghcr.io/ros-controls/ros:${{ inputs.ros_distro }}-ubuntu-testing${{ inputs.docker_image_tag_suffix }}" >> $GITHUB_OUTPUT
           fi
-      - uses: 'mathias-luedtke/industrial_ci@feature/rolling-resolute'
+      - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
           TARGET_WORKSPACE: ${{ inputs.target_workspace }}


### PR DESCRIPTION
https://github.com/ros-industrial/industrial_ci/pull/935

Builds are failing because the last release of pinocchio is not yet available as binary
https://github.com/coal-library/coal/issues/853