### PR TITLE
rhel8: Use RSL and generate_parameter_library from binaries

### DIFF
--- a/.github/workflows/build_and_publish_rhel_docker.yaml
+++ b/.github/workflows/build_and_publish_rhel_docker.yaml
@@ -33,7 +33,7 @@ jobs:
         include:
           - ros_distro: humble
             rhel_version: rhel8
-            source_packages: rsl generate_parameter_library generate_parameter_library_py
+            source_packages: ""
           - ros_distro: jazzy
             rhel_version: rhel9
             source_packages: pinocchio

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -70,13 +70,6 @@ RUN dnf install -y \
   && rosdep init \
   && dnf clean all
 
-# install cmake 3.22.1 (the same version as Ubuntu Jammy default). Needed for RSL
-WORKDIR /usr
-RUN \
-  wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.tar.gz && \
-  tar --strip-components=1 -xzf cmake-3.22.1-linux-x86_64.tar.gz  && \
-  rm cmake-3.22.1-linux-x86_64.tar.gz
-
 # setup colcon mixin and metadata
 RUN colcon mixin add default \
   https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \

--- a/ros2_rhel/Dockerfile.rhel9
+++ b/ros2_rhel/Dockerfile.rhel9
@@ -50,7 +50,7 @@ RUN dnf install -y \
 # install some pip packages needed for testing and
 # not available as RPMs
 # use the same versions as on Ubuntu Jammy
-RUN python3 -m pip install --no-cache-dir -U --user \
+RUN python3 -m pip install --no-cache-dir -U \
   flake8==4.0.1 \
   pyflakes==2.4.0 \
   flake8-blind-except==0.1.1 \


### PR DESCRIPTION
Since https://github.com/ros2/ros_buildfarm_config/pull/335 they should be available as binaries.