### PR TITLE
rhel10: Explicitly install orocos-kdl-devel

### DIFF
--- a/ros2_rhel/Dockerfile.rhel10
+++ b/ros2_rhel/Dockerfile.rhel10
@@ -30,6 +30,7 @@ RUN dnf install -y \
   patch \
   boost-devel \
   libcap-devel \
+  orocos-kdl-devel \
   python3-colcon-common-extensions \
   python3-mypy \
   python3-pip \


### PR DESCRIPTION
hopefully fixes

```

CMake Error at /opt/ros/rolling/share/tf2_geometry_msgs/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  By not providing "Findorocos_kdl.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "orocos_kdl", but CMake did not find one.

  Could not find a package configuration file provided by "orocos_kdl" with
  any of the following names:

    orocos_kdlConfig.cmake
    orocos_kdl-config.cmake

  Add the installation prefix of "orocos_kdl" to CMAKE_PREFIX_PATH or set
  "orocos_kdl_DIR" to a directory containing one of the above files.  If
  "orocos_kdl" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  /opt/ros/rolling/share/tf2_geometry_msgs/cmake/tf2_geometry_msgsConfig.cmake:41 (include)
  CMakeLists.txt:82 (find_package)

```
https://github.com/ros-controls/control_toolbox/actions/runs/25260587732/job/74684853120?pr=604

runtime is installed from rpm, but not the devel one.