### PR TITLE
Don't build coal on debian

### DIFF
--- a/.github/workflows/build_and_publish_debian_docker.yaml
+++ b/.github/workflows/build_and_publish_debian_docker.yaml
@@ -81,7 +81,7 @@ jobs:
           cache-to: type=gha,scope=debian-${{ matrix.ros_distro }},mode=max
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}
-            EXCLUDE_PACKAGES=gz_ros2_control gz_ros2_control_demos ign_ros2_control mujoco_ros2_control ros_gz_sim ros_gz_bridge rviz2 eigenpy hpp-fcl ${{ matrix.exclude_packages }}
+            EXCLUDE_PACKAGES=gz_ros2_control gz_ros2_control_demos ign_ros2_control mujoco_ros2_control ros_gz_sim ros_gz_bridge rviz2 eigenpy hpp-fcl coal ${{ matrix.exclude_packages }}
 
   stack-build:
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Not needed for pinocchio with `-DBUILD_WITH_COLLISION_SUPPORT=OFF`