### PR TITLE
Skip coal package from windows build

### DIFF
--- a/.github/workflows/reusable-ros-tooling-win-build.yml
+++ b/.github/workflows/reusable-ros-tooling-win-build.yml
@@ -40,7 +40,7 @@ on:
         type: string
       skip_dependencies:
         description: "Space-separated list of packages to skip from rosinstall_generator dependency resolution"
-        default: "sdformat_urdf eigenpy hpp-fcl"
+        default: "sdformat_urdf eigenpy hpp-fcl coal"
         required: false
         type: string
       skip_packages:


### PR DESCRIPTION
```
Failed   <<< coal [10min 22s, exited with code 1]
[Processing: coal]
[Processing: coal]
[Processing: coal]

Summary: 3 packages finished [10min 22s]
  1 package failed: coal
  1 package not processed

```
https://github.com/ros-controls/ros2_controllers/actions/runs/25862936160/job/75997290493?pr=2345

Not needed for pinocchio with `-DBUILD_WITH_COLLISION_SUPPORT=OFF`