### PR TITLE
Cache also .venv for mujoco_ros2_control

### DIFF
--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -146,7 +146,9 @@ jobs:
         # save if build step succeeded, but only on default branch to save disk space
         if: ${{ always() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.ici.outputs.build_target_workspace == '0' }}
         with:
-          path: ${{ env.CCACHE_DIR }}
+          path: |
+            ${{ env.CCACHE_DIR }}
+            /root/.ros/ros2_control/.venv
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
 
       - name: Download issue template for target failure  # Has to be a local file


### PR DESCRIPTION
Could improve https://github.com/ros-controls/mujoco_ros2_control/issues/193
But: it needs to succeed once on the default branch to have a successful cache store, which then can be restored the next time:
https://github.com/ros-controls/ros2_control_ci/blob/36196e4ce5d25c834682c501d11325da6e93726f/.github/workflows/reusable-industrial-ci-with-cache.yml#L110-L117

:eyes:  @saikishor maybe we have to increase the timeout to let it be installed for the first time in every installation, it even fails in my local devcontainer:
```
3/6 Test #3: test_robot_launch_mjcf_generation_test.py ..........................***Timeout  75.36 sec
```