### PR TITLE
Use ubuntu resolute docker base image

### DIFF
--- a/ros2_ubuntu/Dockerfile
+++ b/ros2_ubuntu/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-ARG FROM=ubuntu:noble
+ARG FROM=ubuntu:resolute
 FROM ${FROM}
 
 ARG ROS_DISTRO=rolling


### PR DESCRIPTION
This changes the default docker image to ubutu:resiolute instead of noble